### PR TITLE
Fixed: ReadStreamEventsBackward defaults to the end of the stream

### DIFF
--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -670,7 +670,7 @@ class Connection:
             self,
             stream: str,
             direction: msg.StreamDirection = msg.StreamDirection.Forward,
-            from_event: int = 0,
+            from_event: int = None,
             batch_size: int = 100,
             resolve_links: bool = True,
             require_master: bool = False,
@@ -678,7 +678,8 @@ class Connection:
     ):
         correlation_id = correlation_id
         cmd = convo.IterStreamEvents(
-            stream, from_event, batch_size, resolve_links
+            stream, from_event, batch_size, resolve_links,
+            direction=direction
         )
         result = await self.protocol.enqueue_conversation(cmd)
         iterator = await result
@@ -734,6 +735,7 @@ class Connection:
         )
 
         future = await self.protocol.enqueue_conversation(cmd)
+
         return await future
 
     async def connect_subscription(self, subscription: str, stream: str):

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -408,7 +408,7 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
     def __init__(
             self,
             stream: str,
-            from_event: int = 0,
+            from_event: int = None,
             batch_size: int = 100,
             resolve_links: bool = True,
             require_master: bool = False,
@@ -427,13 +427,14 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
         self.resolve_links = resolve_links
         self.require_master = require_master
         self.direction = direction
-        self.from_event = from_event
         self._logger = logging.get_named_logger(IterStreamEvents)
 
         if direction == StreamDirection.Forward:
             self.command = TcpCommand.ReadStreamEventsForward
+            self.from_event = from_event or 0
         else:
             self.command = TcpCommand.ReadStreamEventsBackward
+            self.from_event = from_event or -1
 
     def _fetch_page_message(self, from_event):
         self._logger.debug(


### PR DESCRIPTION
Previously, if we created an IterStreamConversation, the from_event parameter would default to 0 even if the diretion was backward. This meant we would load the first event, and finish.

This PR updates the IterStreamConversation so that the default from_event depends on the direction.