### PR TITLE
Bugfix/dispatcher should not block heartbeats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ services:
 before_install:
   - docker run -d -p 127.0.0.1:1113:1113 eventstore/eventstore
 
-install: make
+install:
+  - "make init"
 
 script:
   - "make travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
 install: make
 
 script:
-  - pytest --cov =./
-  - flake8 --exit-zero
+  - make travis
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 
 python:
     - 3.6
+    - 3.7
+    - 3.5
 
 services:
   - docker
@@ -11,9 +13,7 @@ services:
 before_install:
   - docker run -d -p 127.0.0.1:1113:1113 eventstore/eventstore
 
-install:
-  - pip install -r requirements.txt
-  - pip install -r requirements-test.txt
+install: make
 
 script:
   - pytest --cov =./

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: python
 
 python:
     - 3.6
-    - 3.7
-    - 3.5
 
 services:
   - docker
@@ -16,7 +14,7 @@ before_install:
 install: make
 
 script:
-  - make travis
+  - "make travis"
 
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
+default: fast_tests
+travis: init all_tests
+
+init:
+	pip install pipenv
+	pipenv install --dev
+
 fast_tests: lint
 	pipenv run pytest test/conversations/
+
 all_tests:
 	pipenv run pytest
+
 lint:
 	pipenv run black .
+
 continous_test:
-	pipenv run ptw
+	PYASYNCIODEBUG=1 pipenv run ptw

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default: fast_tests
-travis: init all_tests
+travis: init check_lint all_tests
 
 init:
 	pip install pipenv
@@ -13,6 +13,9 @@ all_tests:
 
 lint:
 	pipenv run black .
+
+check_lint:
+	pipenv run black --check .
 
 continous_test:
 	PYASYNCIODEBUG=1 pipenv run ptw

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,23 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+aioresponses = "*"
+pytest-asyncio = "*"
+colorama = "*"
+"flake8" = "*"
+black = "*"
+pytest-watch = "*"
+testfixtures = "*"
+codecov = "*"
+pytest = "*"
+photon-pump = {editable = true, path = "."}
+pytest-cov = "*"
+neovim = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,475 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c2ee4c0d92c72019816eb0391d6883add7409fef35c78551cd6b03bd522a8d08"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "aiodns": {
+            "hashes": [
+                "sha256:99d0652f2c02f73bfa646bf44af82705260a523014576647d7959e664830b26b",
+                "sha256:d8677adc679ce8d0ef706c14d9c3d2f27a0e0cc11d59730cdbaf218ad52dd9ea"
+            ],
+            "version": "==1.1.1"
+        },
+        "aiohttp": {
+            "hashes": [
+                "sha256:085fa92d2995a1208a60018e15d8690228f3e2f028c93a25246be73e4ccf4db1",
+                "sha256:0c1b1152525b93555c5ac4cdc488b78a3eb1b1121c43f7982920129dc3909379",
+                "sha256:10435eceb05bc01999c9710764e8cb3c2321fe6f62e1c3bbc9223069ceda84af",
+                "sha256:14c07f3de64df4307f8247397a24e8c4f1dc22f50452857409d58f9757faf4c1",
+                "sha256:197104c018048082cce2c617a742cb673a2046ae58b305f84435c467cce71423",
+                "sha256:308dbf8c562526ee6654acd190561fcce5d7724abd25219e6c0bdca75c875fc4",
+                "sha256:39af9e3f9f805b187473a8b936a5616576d753358f2a223ff0990fe974cf72b1",
+                "sha256:4c650bc43e371bb9df8a61a64b84c0c17b6af81addb54c246f01eba3826178b2",
+                "sha256:4fa79cbf74099d835a666b8918a25693f23e630a88ce4c4c60b82688029639d7",
+                "sha256:636f89e534cd68a9e223927506dd3e839410ae20f357dd3680b384f5a537f7e3",
+                "sha256:866afe4be97cf196c702d52cbcc4226ff503d78e922c5a04a8d64d447978dec1",
+                "sha256:92c19a5e609bd24a6451d614676e37c2e38968ec9df69d10b482e70d61ea486f",
+                "sha256:9b182c0f1e30cd57a2d3e554c923fae6024535bd982a6d71fc2512efe4b9d1b2",
+                "sha256:ab2859e0f41ab1e2c63a6c9ff564b588dae2ff297f1dfcce045ea7b7287707cb",
+                "sha256:b55ff305c50c224c31d9286d56546ed39c518c777eda26227e671fbefe600471",
+                "sha256:c599c7df78b776e1796beb106c4f2370e5e29f67cdc507256424ee015df29216",
+                "sha256:d5853be2893ab4080c462a393c561112d5101de4d765d5fed7d02341618f9afa",
+                "sha256:db77132460ef34e96cdd20129424d4f953dc06568fd2ebb474c9000e5443e8d2",
+                "sha256:f20df358f4994482a2c47cb8a523a130bdf5598e5759167032029b94c45bcf27",
+                "sha256:fe68f893d7ade7e8d3600f32678f0c306ae9de744e9515b8baa5d3192b28e0a0",
+                "sha256:fe99213170012571b5cf920c00eba029e2da960dc94a297acdfbd4f1030613d3",
+                "sha256:ff69734e2b8e2b81a3a8cf2bee38b3eef0c370399e209812f8e1e590b4ba234a"
+            ],
+            "version": "==3.4.0a0"
+        },
+        "aioresponses": {
+            "hashes": [
+                "sha256:41d0452fd24256742dc45564a37001c74ec63fe4d4c7a55f365f7fc825c8c56e",
+                "sha256:c3b3c4679579f021356431998a44f0eeaf889a21db1087e290f8d8f44bdef0d2"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
+        },
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "argh": {
+            "hashes": [
+                "sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3",
+                "sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"
+            ],
+            "version": "==0.26.2"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
+                "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
+            ],
+            "markers": "python_version >= '3.5.3'",
+            "version": "==3.0.0"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:22158b89c1a6b4eb333a1e65e791a3f8b998cf3b11ae094adb2570f31f769a44",
+                "sha256:4b475bbd528acce094c503a3d2dbc2d05a4075f6d0ef7d9e7514518e14cc5191"
+            ],
+            "index": "pypi",
+            "version": "==18.6b4"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+            ],
+            "version": "==2018.8.13"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "version": "==6.7"
+        },
+        "codecov": {
+            "hashes": [
+                "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
+                "sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4"
+            ],
+            "index": "pypi",
+            "version": "==2.0.15"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "index": "pypi",
+            "version": "==0.3.9"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:10cfac276cf3dd0acefc49444fc4e1a0a4c23c855d9fcbd555681c3a47a328e6",
+                "sha256:18797137634b64fe488b239d3709e5f8fdea80aea09f86ec819c633a2c84f79c",
+                "sha256:316881a28d2a1a5853495092267fcacf245805b4139f0fc996f8a6c4be6fb499",
+                "sha256:3368098e2c633ec6b2af4f91abde94b5c3b8fa66857452137485f40be77aeda6",
+                "sha256:35fe7a6c06851c4c6a4c171eb796d27e023f5a1ce1e25837ea720f5b8cb76fce",
+                "sha256:3a1c8ed67a64627ef317de64356731f8f173b76457672e933db896c080e1cc2b",
+                "sha256:59fa7e9857205b8d6f6fce0eaea07409bcdffd68eaec3db7e0b1ac720d4fe0f3",
+                "sha256:6b2e2ef7572b399b0cc2f6d05c06ada40329166d6fc58beef8081fb94a41201f",
+                "sha256:712599fc602c302c540fe7e83b6d82aaf381ec5bfb4a51dc5c30f57d214d649f",
+                "sha256:7c8dbbc9e5480856125511f11a5c735cff3200e367adc3ba342dad506a25407d",
+                "sha256:7fc25906ecb0a6af0c434370da6cfbcf8badb257c5cf9a6464f5e37fe4ebc949",
+                "sha256:88d81556e00ac7e1cc9e70a2376859f41e46d187b6dd5883422aa537505f8a98",
+                "sha256:91a915f5fc88db7adace367e8ef65d1a418d29f7ade62514d604eed87c861355",
+                "sha256:9f696b90ff4886ba5a277995397a13b0600bfd97c70d8ae4241c2aecea11ee61",
+                "sha256:a863f4540446d7eeaf6bf716aee277eaf38842718e86bdb80cdca78cdf1fed0d",
+                "sha256:b3b6d8d8194e7e1300240402dfd9c54840d03621e69da821d8ffc8bbebe00137",
+                "sha256:c296ac03ba12e184bef03387d89c4a0be79daff214294917ce77df32240bf4d8",
+                "sha256:c75b3de73cc7ba2e911a907322c65dd10da216f37e7477f22dbd0098775f6345",
+                "sha256:c87c9ee13ce431305734b8e3f0bf00468a1d4f4ee60b6ef63c69282776ab94d6",
+                "sha256:c89c895ff5cfda45a5f681514b647986f76a4f984df125d210c154e5a1a2472b",
+                "sha256:c9fa8fbda281b1ddf25b8fa7ccf0564198a86c9da8a413111fcadd510a98a232",
+                "sha256:ccdf1bd8fd848690fb3d5153d0c54c41169e59804acb9652664f5f669fe25c11"
+            ],
+            "markers": "python_version >= '2.7' and python_version < '4' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.2.*'",
+            "version": "==5.0a1"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
+            ],
+            "index": "pypi",
+            "version": "==3.5.0"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:0411b5bf0de5ec11060925fd811ad49073fa19f995bcf408839eb619b59bb9f7",
+                "sha256:131f4ed14f0fd28d2a9fa50f79a57d5ed1c8f742d3ccac3d773fee09ef6fe217",
+                "sha256:13510d32f8db72a0b3e1720dbf8cba5c4eecdf07abc4cb631982f51256c453d1",
+                "sha256:31dc4d77ef04ab0460d024786f51466dbbc274fda7c8aad0885a6df5ff8d642e",
+                "sha256:35021d9fecea53b21e4defec0ff3ad69a8e2b75aca1ceddd444a5ba71216547e",
+                "sha256:426a8ef9e3b97c27e841648241c2862442c13c91ec4a48c4a72b262ccf30add9",
+                "sha256:58217698193fb94f3e6ff57eed0ae20381a8d06c2bc10151f76c06bb449a3a19",
+                "sha256:5f45adbbb69281845981bb4e0a4efb8a405f10f3cd6c349cb4a5db3357c6bf93",
+                "sha256:5fdb524767288f7ad161d2182f7ed6cafc0a283363728dcd04b9485f6411547c",
+                "sha256:71fbee1f7ef3fb42efa3761a8faefc796e7e425f528de536cfb4c9de03bde885",
+                "sha256:80bd314157851d06f7db7ca527082dbb0ee97afefb529cdcd59f7a5950927ba0",
+                "sha256:b843c9ef6aed54a2649887f55959da0031595ccfaf7e7a0ba7aa681ffeaa0aa1",
+                "sha256:c6a05ef8125503d2d282ccf1448e3599b8a6bd805c3cdee79760fa3da0ea090e",
+                "sha256:deeda2769a52db840efe5bf7bdf7cefa0ae17b43a844a3259d39fb9465c8b008",
+                "sha256:e66f8b09eec1afdcab947d3a1d65b87b25fde39e9172ae1bec562488335633b4",
+                "sha256:e8db93045414980dbada8908d49dbbc0aa134277da3ff613b3e548cb275bdd37",
+                "sha256:f1cc268a15ade58d9a0c04569fe6613e19b8b0345b64453064e2c3c6d79051af",
+                "sha256:fe3001b6a4f3f3582a865b9e5081cc548b973ec20320f297f5e2d46860e9c703",
+                "sha256:fe85bf7adb26eb47ad53a1bae5d35a28df16b2b93b89042a3a28746617a4738d"
+            ],
+            "version": "==0.4.14"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
+            ],
+            "version": "==1.1.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "version": "==4.3.0"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:0b3b1773d2693c70598585a34ca2715873ba899565f0a7c9a1545baef7e7fbdc",
+                "sha256:0bae5d1538c5c6a75642f75a1781f3ac2275d744a92af1a453c150da3446138b",
+                "sha256:0ee8c8c85aa651be3aa0cd005b5931769eaa658c948ce79428766f1bd46ae2c3",
+                "sha256:1369f9edba9500c7a6489b70fdfac773e925342f4531f1e3d4c20ac3173b1ae0",
+                "sha256:22d9c929d1d539f37da3d1b0e16270fa9d46107beab8c0d4d2bddffffe895cee",
+                "sha256:2ff43e3247a1e11d544017bb26f580a68306cec7a6257d8818893c1fda665f42",
+                "sha256:31a98047355d34d047fcdb55b09cb19f633cf214c705a765bd745456c142130c",
+                "sha256:8767eb0032732c3a0da92cbec5ac186ef89a3258c6edca09161472ca0206c45f",
+                "sha256:8acc8910218555044e23826980b950e96685dc48124a290c86f6f41a296ea172",
+                "sha256:ab189a6365be1860a5ecf8159c248f12d33f79ea799ae9695fa6a29896dcf1d4",
+                "sha256:cfd6535feb0f1cf1c7cdb25773e965cc9f92928244a8c3ef6f8f8a8e1f7ae5c4",
+                "sha256:e274cd4480d8c76ec467a85a9c6635bbf2258f0649040560382ab58cabb44bcf",
+                "sha256:f86642d60dca13e93260187d56c2bef2487aa4d574a669e8ceefcf9f4c26fd00",
+                "sha256:f8a57cbda46a94ed0db55b73e6ab0c15e78b4ede8690fa491a0e55128d552bb0",
+                "sha256:fcea97a352416afcbccd7af9625159d80704a25c519c251c734527329bb20d0e"
+            ],
+            "version": "==0.5.6"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:0a80c2c5995e4034f87ba75c57abdb9b20779256452c70d46004c66f53894fbb",
+                "sha256:28187d53b6104829fc64db9290ce99442d78a7d998e8623c3fedc01c309f6c54",
+                "sha256:29070a9744be9438dea43a23f7a9121432776beb324269fcb9951045c98c41db",
+                "sha256:4365ce950cd55316b3818b312b178ba914391146b29adecf1e61a67991755f97",
+                "sha256:4715c33178d474b932fb130912fd69173b1392c1bbac57e5a8581a2bdd614d90",
+                "sha256:4c4d6856caa43fa6504bc85960a64e3b7657c3f9c5b572a310ed8a2ca5149210",
+                "sha256:5f2959f6aee1a40160a83c8008d798e6f79b3f934ae29a043575d40b797b2471",
+                "sha256:60a223bbf27a26961a6a93237545cfab87449514769738daf611d99ce429f443",
+                "sha256:65f782c4e51cba9cb2442c7f04554e19fc5571c83b0d357ee2c922208de1a49f",
+                "sha256:76f48713a05850d3689a4f224ab8fd96bf1b9fd4142d03d6ab7cb309cb209e92",
+                "sha256:80afaa73845a5ce3b88e9b1d2d214877ef416e55af3948456357bd3c4b3704e4",
+                "sha256:8651b1232b89ae6d895c2c53e741a198b4f42f068345fd6094008a2ba95844a2",
+                "sha256:8bb04be39ac6697eef6ba36074bde0d6f3e306669a0390e449f36d4706c5cc98",
+                "sha256:8c5f5208369e0d9eb825f4c06216529296cb255de4c2896924a8ab69a826a983",
+                "sha256:a5cebb878838ada91d5115a29595ad5444bd4befeae9d4a0c0d3a08fcb597699",
+                "sha256:a8145aea8897a6cc45bf651f38e1923765b070b9e2d9388a4f57ee08efd949da",
+                "sha256:bbc8970d20c9e7df69bcb8c68bb70a90d2d44f15fb8f7704a2f89289f81982f1",
+                "sha256:d3929ae6ae38573a0b0254bad5d86acda30c12ae00002bbc10fff7c2febe0800",
+                "sha256:d659521afbf61f745852765e5da99883f0b2618d85136dd5011bd892fdb049ef",
+                "sha256:dfe8282cde9f18aa7bed832b2dec2e13f02936a23b152ba1320755d80e60b9b7",
+                "sha256:f3b578e6a52a76195fa320b1201a3261b23a48ffa6805f57ce36994d532ff930"
+            ],
+            "markers": "python_version >= '3.4.1'",
+            "version": "==4.4.0a38"
+        },
+        "neovim": {
+            "hashes": [
+                "sha256:6ce58a742e0427491c0e1c8108556ee72ba33844209bd9e226b8da9538299276"
+            ],
+            "index": "pypi",
+            "version": "==0.2.6"
+        },
+        "pathtools": {
+            "hashes": [
+                "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
+            ],
+            "version": "==0.1.2"
+        },
+        "photon-pump": {
+            "editable": true,
+            "path": "."
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
+            ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "version": "==0.7.1"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:10394a4d03af7060fa8a6e1cbf38cea44be1467053b0aea5bbfcb4b13c4b88c4",
+                "sha256:1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811",
+                "sha256:1931d8efce896981fe410c802fd66df14f9f429c32a72dd9cfeeac9815ec6444",
+                "sha256:196d3a80f93c537f27d2a19a4fafb826fb4c331b0b99110f985119391d170f96",
+                "sha256:46e34fdcc2b1f2620172d3a4885128705a4e658b9b62355ae5e98f9ea19f42c2",
+                "sha256:59cd75ded98094d3cf2d79e84cdb38a46e33e7441b2826f3838dcc7c07f82995",
+                "sha256:5ee0522eed6680bb5bac5b6d738f7b0923b3cafce8c4b1a039a6107f0841d7ed",
+                "sha256:65917cfd5da9dfc993d5684643063318a2e875f798047911a9dd71ca066641c9",
+                "sha256:685bc4ec61a50f7360c9fd18e277b65db90105adbf9c79938bd315435e526b90",
+                "sha256:92e8418976e52201364a3174e40dc31f5fd8c147186d72380cbda54e0464ee19",
+                "sha256:9335f79d1940dfb9bcaf8ec881fb8ab47d7a2c721fb8b02949aab8bbf8b68625",
+                "sha256:a7ee3bb6de78185e5411487bef8bc1c59ebd97e47713cba3c460ef44e99b3db9",
+                "sha256:ceec283da2323e2431c49de58f80e1718986b79be59c266bb0509cbf90ca5b9e",
+                "sha256:fcfc907746ec22716f05ea96b7f41597dfe1a1c088f861efb8a0d4f4196a6f10"
+            ],
+            "version": "==3.6.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+            ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "version": "==1.5.4"
+        },
+        "pycares": {
+            "hashes": [
+                "sha256:0e81c971236bb0767354f1456e67ab6ae305f248565ce77cd413a311f9572bf5",
+                "sha256:11c0ff3ccdb5a838cbd59a4e59df35d31355a80a61393bca786ca3b44569ba10",
+                "sha256:170d62bd300999227e64da4fa85459728cc96e62e44780bbc86a915fdae01f78",
+                "sha256:36f4c03df57c41a87eb3d642201684eb5a8bc194f4bafaa9f60ee6dc0aef8e40",
+                "sha256:371ce688776da984c4105c8ca760cc60944b9b49ccf8335c71dc7669335e6173",
+                "sha256:3a2234516f7db495083d8bba0ccdaabae587e62cfcd1b8154d5d0b09d3a48dfc",
+                "sha256:3f288586592c697109b2b06e3988b7e17d9765887b5fc367010ee8500cbddc86",
+                "sha256:40134cee03c8bbfbc644d4c0bc81796e12dd012a5257fb146c5a5417812ee5f7",
+                "sha256:722f5d2c5f78d47b13b0112f6daff43ce4e08e8152319524d14f1f917cc5125e",
+                "sha256:7b18fab0ed534a898552df91bc804bd62bb3a2646c11e054baca14d23663e1d6",
+                "sha256:8a39d03bd99ea191f86b990ef67ecce878d6bf6518c5cde9173fb34fb36beb5e",
+                "sha256:8ea263de8bf1a30b0d87150b4aa0e3203cf93bc1723ea3e7408a7d25e1299217",
+                "sha256:943e2dc67ff45ab4c81d628c959837d01561d7e185080ab7a276b8ca67573fb5",
+                "sha256:9d56a54c93e64b30c0d31f394d9890f175edec029cd846221728f99263cdee82",
+                "sha256:b95b339c11d824f0bb789d31b91c8534916fcbdce248cccce216fa2630bb8a90",
+                "sha256:bbfd9aba1e172cd2ab7b7142d49b28cf44d6451c4a66a870aff1dc3cb84849c7",
+                "sha256:d8637bcc2f901aa61ec1d754abc862f9f145cb0346a0249360df4c159377018e",
+                "sha256:e2446577eeea79d2179c9469d9d4ce3ab8a07d7985465c3cb91e7d74abc329b6",
+                "sha256:e72fa163f37ae3b09f143cc6690a36f012d13e905d142e1beed4ec0e593ff657",
+                "sha256:f32b7c63094749fbc0c1106c9a785666ec8afd49ecfe7002a30bb7c42e62b47c",
+                "sha256:f50be4dd53f009cfb4b98c3c6b240e18ff9b17e3f1c320bd594bb83eddabfcb2"
+            ],
+            "version": "==2.3.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+            ],
+            "version": "==2.3.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
+                "sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805"
+            ],
+            "version": "==1.6.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:86a8dbf407e437351cef4dba46736e9c5a6e3c3ac71b2e942209748e76ff2086",
+                "sha256:e74466e97ac14582a8188ff4c53e6cc3810315f342f6096899332ae864c1d432"
+            ],
+            "index": "pypi",
+            "version": "==3.7.1"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:a962e8e1b6ec28648c8fe214edab4e16bacdb37b52df26eb9d63050af309b2a9",
+                "sha256:fbd92c067c16111174a1286bfb253660f1e564e5146b39eeed1133315cf2c2cf"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+            ],
+            "index": "pypi",
+            "version": "==2.5.1"
+        },
+        "pytest-watch": {
+            "hashes": [
+                "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
+                "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
+                "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
+                "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
+                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
+            ],
+            "version": "==4.2b4"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "testfixtures": {
+            "hashes": [
+                "sha256:7e4df89a8bf8b8905464160f08aff131a36f0b33654fe4f9e4387afe546eae25",
+                "sha256:bcadbad77526cc5fc38bfb2ab80da810d7bde56ffe4c7fdb8e2bba122ded9620"
+            ],
+            "index": "pypi",
+            "version": "==6.2.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d"
+            ],
+            "version": "==0.9.4"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version < '4' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.2.*'",
+            "version": "==1.23"
+        },
+        "watchdog": {
+            "hashes": [
+                "sha256:7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162"
+            ],
+            "version": "==0.8.3"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
+            ],
+            "markers": "python_version >= '3.4.1'",
+            "version": "==1.2.6"
+        }
+    },
+    "develop": {}
+}

--- a/photonpump/__init__.py
+++ b/photonpump/__init__.py
@@ -30,3 +30,5 @@ def get_named_logger(cls, name=None):
 logging.Logger.trace = trace
 logging.Logger.insane = insane
 logging.get_named_logger = get_named_logger
+logging.TRACE = TRACE_LEVEL_NUM
+logging.INSANE = INSANE_LEVEL_NUM

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -257,6 +257,72 @@ class Connector:
                 raise NotImplementedError("WAT DO?")
 
 
+class PaceMaker:
+    """
+    Handles heartbeat requests and responses to keep the connection alive.
+    """
+
+    def __init__(
+        self,
+        output_queue: asyncio.Queue,
+        connector: Connector,
+        response_timeout=10,
+        heartbeat_period=30,
+        heartbeat_id=None,
+    ) -> None:
+        self._output = output_queue
+        self.heartbeat_id = heartbeat_id or uuid.uuid4()
+        self._connector = connector
+        self.response_timeout = response_timeout
+        self.heartbeat_period = heartbeat_period
+        self._fut = None
+
+    async def handle_request(self, message: msg.InboundMessage):
+        response = convo.Heartbeat(message.conversation_id)
+        await response.start(self._output)
+
+        return
+
+    async def handle_response(self, message: msg.InboundMessage):
+        if message.conversation_id == self.heartbeat_id:
+            if self._fut:
+                self._fut.set_result(message.conversation_id)
+
+    async def send_heartbeat(self) -> asyncio.Future:
+        fut = asyncio.Future()
+        logging.debug("Sending heartbeat %s to server", self.heartbeat_id)
+        hb = convo.Heartbeat(self.heartbeat_id, direction=convo.Heartbeat.OUTBOUND)
+        await hb.start(self._output)
+        self._fut = fut
+
+        return fut
+
+    async def await_heartbeat_response(self):
+        try:
+            await asyncio.wait_for(self._fut, self.response_timeout)
+            logging.debug("Received heartbeat response from server")
+            self._connector.heartbeat_received(self.heartbeat_id)
+        except asyncio.TimeoutError as e:
+            logging.warning("Heartbeat %s timed out", self.heartbeat_id)
+            self._connector.heartbeat_failed(e)
+        except asyncio.CancelledError:
+            logging.debug("Heartbeat waiter cancelled.")
+            raise
+        except Exception as exn:
+            logging.exception("Heartbeat %s failed", self.heartbeat_id)
+            self._connector.heartbeat_failed(exn)
+
+    async def send_heartbeats(self):
+        while True:
+            try:
+                await self.send_heartbeat()
+                await self.await_heartbeat_response()
+                await asyncio.sleep(self.heartbeat_period)
+            except asyncio.CancelledError:
+                logging.debug("Heartbeat loop cancelled")
+                break
+
+
 class MessageWriter:
     def __init__(
         self,
@@ -296,7 +362,12 @@ class MessageReader:
     HEAD_PACK = struct.Struct("<IBB")
 
     def __init__(
-        self, reader: asyncio.StreamReader, connection_number: int, queue, loop=None
+        self,
+        reader: asyncio.StreamReader,
+        connection_number: int,
+        queue,
+        pacemaker: PaceMaker,
+        loop=None,
     ):
         self._loop = loop or asyncio.get_event_loop()
         self.header_bytes = array.array("B", [0] * (self.MESSAGE_MIN_SIZE))
@@ -308,6 +379,8 @@ class MessageReader:
         self.message_buffer = None
         self._logger = logging.get_named_logger(MessageReader, connection_number)
         self.reader = reader
+        self.pacemaker = pacemaker
+        self._trace_enabled = self._logger.getEffectiveLevel() <= logging.TRACE
 
     def feed_data(self, data):
         self.reader.feed_data(data)
@@ -319,11 +392,13 @@ class MessageReader:
         while True:
             try:
                 data = await self.reader.read(8192)
-                self._logger.trace(
-                    "Received %d bytes from remote server:\n%s",
-                    len(data),
-                    msg.dump(data),
-                )
+
+                if self._trace_enabled:
+                    self._logger.trace(
+                        "Received %d bytes from remote server:\n%s",
+                        len(data),
+                        msg.dump(data),
+                    )
                 await self.process(data)
             except asyncio.CancelledError:
                 return
@@ -392,7 +467,14 @@ class MessageReader:
                     self.conversation_id, self.cmd, self.message_buffer or b""
                 )
                 self._logger.trace("Received message %r", message)
-                await self.queue.put(message)
+
+                if message.command == msg.TcpCommand.HeartbeatRequest:
+                    await self.pacemaker.handle_request(message)
+                elif message.command == msg.TcpCommand.HeartbeatResponse:
+                    await self.pacemaker.handle_response(message)
+                else:
+                    await self.queue.put(message)
+
                 self.length = -1
                 self.message_offset = 0
                 self.conversation_id = None
@@ -417,8 +499,10 @@ class MessageDispatcher:
                 conversation,
                 None,
             )
+
         if self.output:
             await conversation.start(self.output)
+
         return conversation.result
 
     async def write_to(self, output: asyncio.Queue):
@@ -434,12 +518,6 @@ class MessageDispatcher:
     async def dispatch(self, message: msg.InboundMessage, output: asyncio.Queue):
         self._logger.debug("Received message %s", message)
 
-        if message.command == msg.TcpCommand.HeartbeatRequest.value:
-            response = convo.Heartbeat(message.conversation_id)
-            await response.start(output)
-
-            return
-
         conversation, result = self.active_conversations.get(
             message.conversation_id, (None, None)
         )
@@ -450,6 +528,7 @@ class MessageDispatcher:
             return
 
         await conversation.respond_to(message, output)
+
         if conversation.is_complete:
             del self.active_conversations[conversation.conversation_id]
 
@@ -474,22 +553,11 @@ class Client:
         self.connector = connector
         self.dispatcher = dispatcher
 
-        self.connector.connected.append(self.on_connected)
-        self.connector.disconnected.append(self.on_disconnected)
-
         self.credential = credential
         self.outstanding_heartbeat = None
-        self.heartbeat_loop = None
 
     async def connect(self):
         await self.connector.start()
-
-    def on_connected(self, *args):
-        self.heartbeat_loop = asyncio.ensure_future(self.send_heartbeats())
-
-    def on_disconnected(self, *args):
-        if self.heartbeat_loop:
-            self.heartbeat_loop.cancel()
 
     async def close(self):
         await self.connector.stop()
@@ -666,32 +734,6 @@ class Client:
         )
         await self.dispatcher.start_conversation(cmd)
 
-    async def send_heartbeats(self):
-        heartbeat_id = uuid.uuid4()
-
-        while True:
-            logging.debug("Sending heartbeat %s to server", heartbeat_id)
-            hb = convo.Heartbeat(heartbeat_id, direction=convo.Heartbeat.OUTBOUND)
-            fut = await self.dispatcher.start_conversation(hb)
-
-            try:
-                await asyncio.wait_for(fut, 10)
-                logging.debug("Received heartbeat response from server")
-                self.connector.heartbeat_received(hb.conversation_id)
-                await asyncio.sleep(30)
-            except asyncio.TimeoutError as e:
-                logging.warning("Heartbeat %s timed out", hb.conversation_id)
-                self.connector.heartbeat_failed(e)
-                self.dispatcher.remove(hb.conversation_id)
-            except asyncio.CancelledError:
-                self.dispatcher.remove(hb.conversation_id)
-
-                return
-            except Exception as exn:
-                logging.exception("Heartbeat %s failed", hb.conversation_id)
-                self.dispatcher.remove(hb.conversation_id)
-                self.connector.heartbeat_failed(exn)
-
     async def __aenter__(self):
         await self.connect()
 
@@ -728,9 +770,10 @@ class PhotonPumpProtocol(asyncio.streams.FlowControlMixin):
         stream_reader = asyncio.StreamReader(loop=self.loop)
         stream_reader.set_transport(transport)
         stream_writer = asyncio.StreamWriter(transport, self, stream_reader, self.loop)
+        self.pacemaker = PaceMaker(self.output_queue, self.connector)
 
         self.reader = MessageReader(
-            stream_reader, self.connection_number, self.input_queue
+            stream_reader, self.connection_number, self.input_queue, self.pacemaker
         )
         self.writer = MessageWriter(
             stream_writer, self.connection_number, self.output_queue
@@ -739,6 +782,7 @@ class PhotonPumpProtocol(asyncio.streams.FlowControlMixin):
         self.write_loop = asyncio.ensure_future(self.writer.start())
         self.read_loop = asyncio.ensure_future(self.reader.start())
         self.dispatch_loop = asyncio.ensure_future(self.dispatch())
+        self.heartbeat_loop = asyncio.ensure_future(self.pacemaker.send_heartbeats())
         self.connector.connection_made(self.node, self)
 
     def data_received(self, data):
@@ -753,6 +797,7 @@ class PhotonPumpProtocol(asyncio.streams.FlowControlMixin):
                 break
             except:
                 logging.exception("Dispatch loop failed")
+
                 break
 
     def connection_lost(self, exn):
@@ -767,12 +812,15 @@ class PhotonPumpProtocol(asyncio.streams.FlowControlMixin):
             self.read_loop.cancel()
             self.write_loop.cancel()
             self.dispatch_loop.cancel()
+            self.heartbeat_loop.cancel()
             self._log.debug("Waiting for coroutines to end")
             await asyncio.gather(
                 self.read_loop,
                 self.write_loop,
                 self.dispatch_loop,
+                self.heartbeat_loop,
                 loop=self.loop,
+
                 return_exceptions=True,
             )
             self.transport.close()

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -820,7 +820,6 @@ class PhotonPumpProtocol(asyncio.streams.FlowControlMixin):
                 self.dispatch_loop,
                 self.heartbeat_loop,
                 loop=self.loop,
-
                 return_exceptions=True,
             )
             self.transport.close()

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -12,14 +12,24 @@ from photonpump import exceptions
 from photonpump import messages as messages
 from photonpump import messages_pb2 as proto
 from photonpump.messages import (
-    ContentType, Credential, ExpectedVersion, InboundMessage, NewEvent,
-    NotHandledReason, OutboundMessage, ReadEventResult, ReadStreamResult,
-    StreamDirection, StreamSlice, SubscriptionResult, TcpCommand, _make_event
+    ContentType,
+    Credential,
+    ExpectedVersion,
+    InboundMessage,
+    NewEvent,
+    NotHandledReason,
+    OutboundMessage,
+    ReadEventResult,
+    ReadStreamResult,
+    StreamDirection,
+    StreamSlice,
+    SubscriptionResult,
+    TcpCommand,
+    _make_event,
 )
 
 
 class StreamingIterator:
-
     def __init__(self, size=0):
         self.items = Queue(size)
         self.finished = False
@@ -61,11 +71,10 @@ class StreamingIterator:
 
 
 class Conversation:
-
     def __init__(
-            self,
-            conversation_id: Optional[UUID] = None,
-            credential: Optional[Credential] = None
+        self,
+        conversation_id: Optional[UUID] = None,
+        credential: Optional[Credential] = None,
     ) -> None:
         self.conversation_id = conversation_id or uuid4()
         self.result: Future = Future()
@@ -100,9 +109,7 @@ class Conversation:
     async def respond_to(self, response: InboundMessage, output: Queue) -> None:
         try:
             if response.command is TcpCommand.BadRequest:
-                return await self.conversation_error(
-                    exceptions.BadRequest, response
-                )
+                return await self.conversation_error(exceptions.BadRequest, response)
 
             if response.command is TcpCommand.NotAuthenticated:
                 return await self.conversation_error(
@@ -114,7 +121,7 @@ class Conversation:
 
             return await self.reply(response, output)
         except Exception as exn:
-            self._logger.error('Failed to read server response', exc_info=True)
+            self._logger.error("Failed to read server response", exc_info=True)
 
             return await self.error(
                 exceptions.PayloadUnreadable(
@@ -138,14 +145,13 @@ class Conversation:
         return await self.error(exn)
 
     async def conversation_error(self, exn_type, response) -> None:
-        error = response.payload.decode('UTF-8')
+        error = response.payload.decode("UTF-8")
         exn = exn_type(self.conversation_id, error)
 
         return await self.error(exn)
 
 
 class TimerConversation(Conversation):
-
     def __init__(self, conversation_id, credential):
         super().__init__(conversation_id, credential)
         self.started_at = time.perf_counter()
@@ -166,7 +172,7 @@ class Heartbeat(TimerConversation):
     OUTBOUND = 1
 
     def __init__(
-            self, conversation_id: UUID, direction=INBOUND, credential=None
+        self, conversation_id: UUID, direction=INBOUND, credential=None
     ) -> None:
         super().__init__(conversation_id, credential=None)
         self.direction = direction
@@ -185,11 +191,7 @@ class Heartbeat(TimerConversation):
 
         await output.put(
             OutboundMessage(
-                self.conversation_id,
-                cmd,
-                b'',
-                self.credential,
-                one_way=one_way
+                self.conversation_id, cmd, b"", self.credential, one_way=one_way
             )
         )
 
@@ -199,7 +201,6 @@ class Heartbeat(TimerConversation):
 
 
 class Ping(TimerConversation):
-
     def __init__(self, conversation_id: UUID = None, credential=None) -> None:
         super().__init__(conversation_id or uuid4(), credential)
 
@@ -209,7 +210,7 @@ class Ping(TimerConversation):
         if output:
             await output.put(
                 OutboundMessage(
-                    self.conversation_id, TcpCommand.Ping, b'', self.credential
+                    self.conversation_id, TcpCommand.Ping, b"", self.credential
                 )
             )
 
@@ -237,14 +238,14 @@ class WriteEvents(Conversation):
     """
 
     def __init__(
-            self,
-            stream: str,
-            events: Sequence[NewEvent],
-            expected_version: Union[ExpectedVersion, int] = ExpectedVersion.Any,
-            require_master: bool = False,
-            conversation_id: UUID = None,
-            credential=None,
-            loop=None
+        self,
+        stream: str,
+        events: Sequence[NewEvent],
+        expected_version: Union[ExpectedVersion, int] = ExpectedVersion.Any,
+        require_master: bool = False,
+        conversation_id: UUID = None,
+        credential=None,
+        loop=None,
     ):
         super().__init__(conversation_id, credential)
         self._logger = logging.get_named_logger(WriteEvents)
@@ -266,17 +267,17 @@ class WriteEvents(Conversation):
 
             if isinstance(event.data, str):
                 e.data_content_type = ContentType.Json
-                e.data = event.data.encode('UTF-8')
+                e.data = event.data.encode("UTF-8")
             elif event.data:
                 e.data_content_type = ContentType.Json
-                e.data = json.dumps(event.data).encode('UTF-8')
+                e.data = json.dumps(event.data).encode("UTF-8")
             else:
                 e.data_content_type = ContentType.Binary
                 e.data = bytes()
 
             if event.metadata:
                 e.metadata_content_type = ContentType.Json
-                e.metadata = json.dumps(event.metadata).encode('UTF-8')
+                e.metadata = json.dumps(event.metadata).encode("UTF-8")
             else:
                 e.metadata_content_type = ContentType.Binary
                 e.metadata = bytes()
@@ -285,8 +286,7 @@ class WriteEvents(Conversation):
 
         await output.put(
             OutboundMessage(
-                self.conversation_id, TcpCommand.WriteEvents, data,
-                self.credential
+                self.conversation_id, TcpCommand.WriteEvents, data, self.credential
             )
         )
 
@@ -302,7 +302,6 @@ class WriteEvents(Conversation):
 
 
 class ReadStreamEventsBehaviour:
-
     def __init__(self, result_type, response_cls):
         self.result_type = result_type
         self.response_cls = response_cls
@@ -328,9 +327,7 @@ class ReadStreamEventsBehaviour:
             )
         elif result.result == self.result_type.Error:
             await self.error(
-                exceptions.ReadError(
-                    self.conversation_id, self.stream, result.error
-                )
+                exceptions.ReadError(self.conversation_id, self.stream, result.error)
             )
         elif result.result == self.result_type.AccessDenied:
             await self.error(
@@ -338,10 +335,13 @@ class ReadStreamEventsBehaviour:
                     self.conversation_id,
                     type(self).__name__,
                     result.error,
-                    stream=self.stream
+                    stream=self.stream,
                 )
             )
-        elif self.result_type == ReadEventResult and result.result == self.result_type.NotFound:
+        elif (
+            self.result_type == ReadEventResult
+            and result.result == self.result_type.NotFound
+        ):
             await self.error(
                 exceptions.EventNotFound(
                     self.conversation_id, self.stream, self.event_number
@@ -365,18 +365,16 @@ class ReadEvent(ReadStreamEventsBehaviour, Conversation):
     """
 
     def __init__(
-            self,
-            stream: str,
-            event_number: int,
-            resolve_links: bool = True,
-            require_master: bool = False,
-            conversation_id: Optional[UUID] = None,
-            credentials=None
+        self,
+        stream: str,
+        event_number: int,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        conversation_id: Optional[UUID] = None,
+        credentials=None,
     ) -> None:
 
-        Conversation.__init__(
-            self, conversation_id, credential=credentials
-        )
+        Conversation.__init__(self, conversation_id, credential=credentials)
         ReadStreamEventsBehaviour.__init__(
             self, ReadEventResult, proto.ReadEventCompleted
         )
@@ -420,20 +418,18 @@ class ReadStreamEvents(ReadStreamEventsBehaviour, Conversation):
     """
 
     def __init__(
-            self,
-            stream: str,
-            from_event: int = 0,
-            max_count: int = 100,
-            resolve_links: bool = True,
-            require_master: bool = False,
-            direction: StreamDirection = StreamDirection.Forward,
-            credentials=None,
-            conversation_id: UUID = None
+        self,
+        stream: str,
+        from_event: int = 0,
+        max_count: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        direction: StreamDirection = StreamDirection.Forward,
+        credentials=None,
+        conversation_id: UUID = None,
     ) -> None:
 
-        Conversation.__init__(
-            self, conversation_id, credential=credentials
-        )
+        Conversation.__init__(self, conversation_id, credential=credentials)
         ReadStreamEventsBehaviour.__init__(
             self, ReadStreamResult, proto.ReadStreamEventsCompleted
         )
@@ -459,23 +455,23 @@ class ReadStreamEvents(ReadStreamEventsBehaviour, Conversation):
 
         data = msg.SerializeToString()
 
-        return OutboundMessage(
-            self.conversation_id, command, data, self.credential
-        )
+        return OutboundMessage(self.conversation_id, command, data, self.credential)
 
     async def start(self, output):
         await output.put(self._fetch_page_message(self.from_event))
 
-    async def success(
-            self, result: proto.ReadStreamEventsCompleted, output: Queue
-    ):
+    async def success(self, result: proto.ReadStreamEventsCompleted, output: Queue):
         events = [_make_event(x) for x in result.events]
 
         self.is_complete = True
         self.result.set_result(
             StreamSlice(
-                events, result.next_event_number, result.last_event_number,
-                None, result.last_commit_position, result.is_end_of_stream
+                events,
+                result.next_event_number,
+                result.last_event_number,
+                None,
+                result.last_commit_position,
+                result.is_end_of_stream,
             )
         )
 
@@ -495,15 +491,15 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
     """
 
     def __init__(
-            self,
-            stream: str,
-            from_event: int = None,
-            batch_size: int = 100,
-            resolve_links: bool = True,
-            require_master: bool = False,
-            direction: StreamDirection = StreamDirection.Forward,
-            credentials=None,
-            conversation_id: UUID = None
+        self,
+        stream: str,
+        from_event: int = None,
+        batch_size: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        direction: StreamDirection = StreamDirection.Forward,
+        credentials=None,
+        conversation_id: UUID = None,
     ):
 
         Conversation.__init__(self, conversation_id, credentials)
@@ -528,8 +524,9 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
 
     def _fetch_page_message(self, from_event):
         self._logger.debug(
-            "Requesting page of %d events from number %d", self.batch_size,
-            self.from_event
+            "Requesting page of %d events from number %d",
+            self.batch_size,
+            self.from_event,
         )
 
         if self.direction == StreamDirection.Forward:
@@ -546,16 +543,12 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
 
         data = msg.SerializeToString()
 
-        return OutboundMessage(
-            self.conversation_id, command, data, self.credential
-        )
+        return OutboundMessage(self.conversation_id, command, data, self.credential)
 
     async def start(self, output: Queue):
         await output.put(self._fetch_page_message(self.from_event))
 
-    async def success(
-            self, result: proto.ReadStreamEventsCompleted, output: Queue
-    ):
+    async def success(self, result: proto.ReadStreamEventsCompleted, output: Queue):
         events = [_make_event(x) for x in result.events]
         await self.iterator.enqueue_items(events)
 
@@ -579,17 +572,16 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
 
 
 class PersistentSubscription:
-
     def __init__(
-            self,
-            name,
-            stream,
-            correlation_id,
-            initial_commit,
-            initial_event_number,
-            buffer_size,
-            out_queue,
-            auto_ack=False
+        self,
+        name,
+        stream,
+        correlation_id,
+        initial_commit,
+        initial_event_number,
+        buffer_size,
+        out_queue,
+        auto_ack=False,
     ):
         self.initial_commit_position = initial_commit
         self.name = name
@@ -603,7 +595,9 @@ class PersistentSubscription:
 
     def __str__(self):
         return "Subscription in group %s to %s at event number %d" % (
-            self.name, self.stream, self.last_event_number
+            self.name,
+            self.stream,
+            self.last_event_number,
         )
 
     async def ack(self, event):
@@ -620,27 +614,26 @@ class PersistentSubscription:
 
 
 class CreatePersistentSubscription(Conversation):
-
     def __init__(
-            self,
-            name,
-            stream,
-            resolve_links=True,
-            start_from=-1,
-            timeout_ms=30000,
-            record_statistics=False,
-            live_buffer_size=500,
-            read_batch_size=500,
-            buffer_size=1000,
-            max_retry_count=10,
-            prefer_round_robin=True,
-            checkpoint_after_ms=2000,
-            checkpoint_max_count=1024,
-            checkpoint_min_count=10,
-            subscriber_max_count=10,
-            credentials=None,
-            conversation_id=None,
-            consumer_strategy=messages.ROUND_ROBIN
+        self,
+        name,
+        stream,
+        resolve_links=True,
+        start_from=-1,
+        timeout_ms=30000,
+        record_statistics=False,
+        live_buffer_size=500,
+        read_batch_size=500,
+        buffer_size=1000,
+        max_retry_count=10,
+        prefer_round_robin=True,
+        checkpoint_after_ms=2000,
+        checkpoint_max_count=1024,
+        checkpoint_min_count=10,
+        subscriber_max_count=10,
+        credentials=None,
+        conversation_id=None,
+        consumer_strategy=messages.ROUND_ROBIN,
     ) -> None:
         super().__init__(conversation_id, credentials)
         self.stream = stream
@@ -681,15 +674,15 @@ class CreatePersistentSubscription(Conversation):
 
         await output.put(
             OutboundMessage(
-                self.conversation_id, TcpCommand.CreatePersistentSubscription,
-                msg.SerializeToString(), self.credential
+                self.conversation_id,
+                TcpCommand.CreatePersistentSubscription,
+                msg.SerializeToString(),
+                self.credential,
             )
         )
 
     async def reply(self, message: InboundMessage, output: Queue) -> None:
-        self.expect_only(
-            TcpCommand.CreatePersistentSubscriptionCompleted, message
-        )
+        self.expect_only(TcpCommand.CreatePersistentSubscriptionCompleted, message)
 
         result = proto.CreatePersistentSubscriptionCompleted()
         result.ParseFromString(message.payload)
@@ -700,8 +693,7 @@ class CreatePersistentSubscription(Conversation):
         elif result.result == SubscriptionResult.AccessDenied:
             await self.error(
                 exceptions.AccessDenied(
-                    self.conversation_id,
-                    type(self).__name__, result.reason
+                    self.conversation_id, type(self).__name__, result.reason
                 )
             )
         else:
@@ -713,20 +705,19 @@ class CreatePersistentSubscription(Conversation):
 
 
 class ConnectPersistentSubscription(Conversation):
-
     class State(IntEnum):
         init = 0
         catch_up = 1
         live = 2
 
     def __init__(
-            self,
-            name,
-            stream,
-            max_in_flight=10,
-            credentials=None,
-            conversation_id=None,
-            auto_ack=False
+        self,
+        name,
+        stream,
+        max_in_flight=10,
+        credentials=None,
+        conversation_id=None,
+        auto_ack=False,
     ) -> None:
         super().__init__(conversation_id, credentials)
         self.stream = stream
@@ -745,21 +736,25 @@ class ConnectPersistentSubscription(Conversation):
             OutboundMessage(
                 self.conversation_id,
                 TcpCommand.ConnectToPersistentSubscription,
-                msg.SerializeToString(), self.credential
+                msg.SerializeToString(),
+                self.credential,
             )
         )
 
     def reply_from_init(self, response: InboundMessage, output: Queue):
-        self.expect_only(
-            TcpCommand.PersistentSubscriptionConfirmation, response
-        )
+        self.expect_only(TcpCommand.PersistentSubscriptionConfirmation, response)
         result = proto.PersistentSubscriptionConfirmation()
         result.ParseFromString(response.payload)
 
         self.subscription = PersistentSubscription(
-            result.subscription_id, self.stream, self.conversation_id,
-            result.last_commit_position, result.last_event_number,
-            self.max_in_flight, output, self.auto_ack
+            result.subscription_id,
+            self.stream,
+            self.conversation_id,
+            result.last_commit_position,
+            result.last_event_number,
+            self.max_in_flight,
+            output,
+            self.auto_ack,
         )
 
         self.is_live = True
@@ -770,9 +765,7 @@ class ConnectPersistentSubscription(Conversation):
             self.subscription.out_queue = output
             return
 
-        self.expect_only(
-            TcpCommand.PersistentSubscriptionStreamEventAppeared, response
-        )
+        self.expect_only(TcpCommand.PersistentSubscriptionStreamEventAppeared, response)
         result = proto.StreamEventAppeared()
         result.ParseFromString(response.payload)
         await self.subscription.events.enqueue(_make_event(result.event))
@@ -781,23 +774,19 @@ class ConnectPersistentSubscription(Conversation):
         body = proto.SubscriptionDropped()
         body.ParseFromString(response.payload)
 
-        if (self.is_live and body.reason == messages.SubscriptionDropReason.Unsubscribed):
+        if self.is_live and body.reason == messages.SubscriptionDropReason.Unsubscribed:
 
             await self.subscription.events.enqueue(StopAsyncIteration())
             return
 
         if self.is_live:
             await self.error(
-                exceptions.SubscriptionFailed(
-                    self.conversation_id, body.reason
-                )
+                exceptions.SubscriptionFailed(self.conversation_id, body.reason)
             )
             return
 
         await self.error(
-            exceptions.SubscriptionCreationFailed(
-                self.conversation_id, body.reason
-            )
+            exceptions.SubscriptionCreationFailed(self.conversation_id, body.reason)
         )
 
     async def error(self, exn) -> None:

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -549,6 +549,10 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
         await output.put(self._fetch_page_message(self.from_event))
 
     async def success(self, result: proto.ReadStreamEventsCompleted, output: Queue):
+
+        if not result.is_end_of_stream:
+            await output.put(self._fetch_page_message(result.next_event_number))
+
         events = [_make_event(x) for x in result.events]
         await self.iterator.enqueue_items(events)
 
@@ -559,8 +563,6 @@ class IterStreamEvents(ReadStreamEventsBehaviour, Conversation):
         if result.is_end_of_stream:
             self.is_complete = True
             await self.iterator.asend(StopAsyncIteration())
-        else:
-            await output.put(self._fetch_page_message(result.next_event_number))
 
     async def error(self, exn: Exception) -> None:
         self.is_complete = True

--- a/test/connection/test_connector.py
+++ b/test/connection/test_connector.py
@@ -97,7 +97,7 @@ async def test_when_a_server_disconnects(event_loop):
         server.stop()
 
         disconnect = await queue.next_event()
-        assert disconnect.command == ConnectorCommand.HandleConnectionClosed
+        assert disconnect.command == ConnectorCommand.HandleConnectionFailed
 
         reconnect = await queue.next_event()
         assert reconnect.command == ConnectorCommand.Connect

--- a/test/connection/test_dispatcher.py
+++ b/test/connection/test_dispatcher.py
@@ -76,27 +76,6 @@ async def test_when_enqueuing_a_conversation():
 
 
 @pytest.mark.asyncio
-async def test_when_receiving_a_heartbeat_request():
-    """
-    When we receive a HeartbeatRequest from the server, we should
-    immediately respond with a HeartbeatResponse
-    """
-    dispatcher = MessageDispatcher()
-    out_queue = TeeQueue()
-
-    heartbeat_id = uuid.uuid4()
-
-    await dispatcher.dispatch(
-        InboundMessage(heartbeat_id, TcpCommand.HeartbeatRequest, bytes()), out_queue
-    )
-
-    response = await out_queue.get()
-    assert response == OutboundMessage(
-        heartbeat_id, TcpCommand.HeartbeatResponse, bytes()
-    )
-
-
-@pytest.mark.asyncio
 async def test_when_the_conversation_raises_an_error():
     """
     If the conversation raises an error, that error should be returned

--- a/test/connection/test_pacemaker.py
+++ b/test/connection/test_pacemaker.py
@@ -1,0 +1,158 @@
+"""
+The Pacemaker exists to send and receive heartbeats.
+
+The MessageDispatcher used to receive heartbeats and reply to them but
+this leads to dropped connections if we're not processing our received
+messages quickly enough.
+
+While that's a primitive form of flow control, it's sort of annoying that
+an application-level issue can cause connection-level outages, so we
+introduce the pacemaker.
+
+The MessageReader receives HeartbeatRequest commands from the server and
+gives them to the Pacemaker, who sends a reply to the MessageWriter.
+
+Periodically, the Pacemaker sends his own HeartbeatRequest to the server
+and waits for a response, raising a TimeoutError after a configurable period.
+
+This allows us to detect half-closed TCP connections.
+"""
+
+
+import asyncio
+import pytest
+import uuid
+from photonpump.connection import PaceMaker
+from photonpump.messages import InboundMessage, OutboundMessage, TcpCommand
+
+from .test_connector import TeeQueue
+from ..fakes import FakeConnector
+
+
+@pytest.mark.asyncio
+async def test_when_receiving_a_heartbeat_request():
+    """
+    When we receive a HeartbeatRequest from the server, we should
+    immediately respond with a HeartbeatResponse
+    """
+    out_queue = TeeQueue()
+    pace_maker = PaceMaker(out_queue, None)
+
+    heartbeat_id = uuid.uuid4()
+
+    await pace_maker.handle_request(
+        InboundMessage(heartbeat_id, TcpCommand.HeartbeatRequest, bytes())
+    )
+
+    response = await out_queue.get()
+    assert response == OutboundMessage(
+        heartbeat_id, TcpCommand.HeartbeatResponse, bytes()
+    )
+
+
+@pytest.mark.asyncio
+async def test_when_sending_a_heartbeat_request():
+    """
+    Periodically, the Pacemaker sends a heartbeat request to the server.
+    """
+
+    heartbeat_id = uuid.uuid4()
+    out_queue = TeeQueue()
+    pace_maker = PaceMaker(out_queue, None, heartbeat_id=heartbeat_id)
+
+    await pace_maker.send_heartbeat()
+
+    [request] = out_queue.items
+
+    assert request == OutboundMessage(
+        heartbeat_id, TcpCommand.HeartbeatRequest, bytes()
+    )
+
+
+@pytest.mark.asyncio
+async def test_when_the_heartbeat_times_out():
+    """
+    If the heartbeat times, out we should tell the connector.
+    """
+
+    heartbeat_id = uuid.uuid4()
+    out_queue = TeeQueue()
+    connector = FakeConnector()
+    pace_maker = PaceMaker(out_queue, connector, heartbeat_id=heartbeat_id)
+
+    timeout = asyncio.TimeoutError("lol, timed out, sorry")
+
+    fut = await pace_maker.send_heartbeat()
+    fut.set_exception(timeout)
+
+    await pace_maker.await_heartbeat_response()
+
+    assert connector.failures == [timeout]
+    assert connector.successes == 0
+
+
+@pytest.mark.asyncio
+async def test_when_the_heartbeat_fails():
+    """
+    If the heartbeat fails because lol random, we should tell the connector.
+    """
+
+    heartbeat_id = uuid.uuid4()
+    out_queue = TeeQueue()
+    connector = FakeConnector()
+    pace_maker = PaceMaker(out_queue, connector, heartbeat_id=heartbeat_id)
+
+    exn = KeyError("How even could this happen?")
+
+    fut = await pace_maker.send_heartbeat()
+    fut.set_exception(exn)
+
+    await pace_maker.await_heartbeat_response()
+
+    assert connector.failures == [exn]
+    assert connector.successes == 0
+
+
+@pytest.mark.asyncio
+async def test_when_the_heartbeat_is_cancelled():
+    """
+    If the heartbeat fails with a cancellation error we shouldn't
+    worry about it.
+    """
+
+    heartbeat_id = uuid.uuid4()
+    out_queue = TeeQueue()
+    connector = FakeConnector()
+    pace_maker = PaceMaker(out_queue, connector, heartbeat_id=heartbeat_id)
+
+    fut = await pace_maker.send_heartbeat()
+    fut.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pace_maker.await_heartbeat_response()
+
+    assert connector.failures == []
+    assert connector.successes == 0
+
+
+@pytest.mark.asyncio
+async def test_when_the_heartbeat_succeeds():
+    """
+    If the heartbeat receives a response within the timeout period
+    we should record the success.
+    """
+
+    heartbeat_id = uuid.uuid4()
+    out_queue = TeeQueue()
+    connector = FakeConnector()
+    pace_maker = PaceMaker(out_queue, connector, heartbeat_id=heartbeat_id)
+
+    await pace_maker.send_heartbeat()
+    await pace_maker.handle_response(
+        InboundMessage(heartbeat_id, TcpCommand.HeartbeatResponse, bytes())
+    )
+
+    await pace_maker.await_heartbeat_response()
+
+    assert connector.failures == []
+    assert connector.successes == 1

--- a/test/fakes.py
+++ b/test/fakes.py
@@ -124,3 +124,11 @@ class FakeConnector:
         self.connected = Event()
         self.disconnected = Event()
         self.stopped = Event()
+        self.failures = []
+        self.successes = 0
+
+    def heartbeat_received(self, conversation_id):
+        self.successes += 1
+
+    def heartbeat_failed(self, exn):
+        self.failures.append(exn)


### PR DESCRIPTION
This PR introduces a new class `PaceMaker` whose job is to send and receive heartbeat messages. Taking this responsibility away from the MessageDispatcher stops us timing out heartbeats just because a message is taking time to process in the application.

We can still fail to receive heartbeats if we receive large messages from the server. There's almost certainly a ton of performance tuning we could do inside the `MessageReader` to help with this case.

Minor Tweaks:

* When paging through a stream with the IterStreamEvents conversation, we now request page N+1 before yielding events from page N; this means less time waiting for responses because we can receive the next page before we've finished processing the last one.
* Added an ugly conditional so that we don't waste time formatting a dump unless we're actually running in trace mode.