### PR TITLE
Document how to debug without getting turfed out

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,3 +251,25 @@ If you provide both a `host` and `discovery_host`, photonpump will prefer discov
 .. _Eventstore: http://geteventstore.com
 .. _cheese shop: https://pypi.python.org/pypi/photon-pump
 .. _Read the docs: http://photon-pump.readthedocs.io/en/latest/ 
+
+
+Debugging
+~~~~~~~~~
+
+If you want to step through code that uses photonpump, it's helpful to be aware that Event Store's TCP API (which photonpump uses) makes use of a 'heartbeat' to ensure that connections are not left open. This means that if you're sitting at a debugger (e.g. pdb) prompt -- and therefore not running the event loop for tens of seconds at a time -- you'll find that you get disconnected. To prevent that, you can run it with Event Store's heartbeat timeouts set to high values -- e.g. with a `Dockerfile` like this:
+
+    FROM eventstore/eventstore
+    COPY eventstore.conf /etc/eventstore/
+
+and and eventstore.conf alongside that like this:
+
+    IntIp: 0.0.0.0
+    ExtIp: 0.0.0.0
+    IntHttpPrefixes: http://*:2112/
+    ExtHttpPrefixes: http://*:2113/
+    AddInterfacePrefixes: false
+    RunProjections: All
+    IntTcpHeartbeatTimeout: 99999999
+    ExtTcpHeartbeatTimeout: 99999999
+    IntTcpHeartbeatInterval: 99999999
+    ExtTcpHeartbeatInterval: 99999999


### PR DESCRIPTION
I suspect there's a better way (e.g. by feeding the configuration parameters via
photonpump code)?  If not I should probably move this to a tiny repo for this
Dockerfile and point at that...