### PR TITLE
Feature/configurable discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - `published_event` reversed order of type and stream
 
 
+[0.6]: https://github.com/madecom/photon-pump/compare/v0.5.0...v0.6.0
 [0.5]: https://github.com/madecom/photon-pump/compare/v0.4.0...v0.5.0
 [0.4]: https://github.com/madecom/photon-pump/compare/v0.3.0...v0.4.0
 [0.3]: https://github.com/madecom/photon-pump/compare/v0.2.5...v0.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.6-alpha-2] - 2018-09-17
+Discovery now supports "selectors" to control how we pick a node from gossip
+
+## [0.6-alpha-1] - 2018-09-14
+Added support for catch-up subscriptions.
+
 ## [0.5] - 2018-04-27
 ### Breaking changes
  - Dropped the ConnectionContextManager class.
@@ -16,7 +22,8 @@
 - `published_event` reversed order of type and stream
 
 
-[0.6]: https://github.com/madecom/photon-pump/compare/v0.5.0...v0.6.0
+[0.6.0-alpha-2]: https://github.com/madecom/photon-pump/compare/v0.6.0-alpha-1...v0.6.0-alpha-2
+[0.6.0-alpha-1]: https://github.com/madecom/photon-pump/compare/v0.5.0...v0.6.0-alpha-1
 [0.5]: https://github.com/madecom/photon-pump/compare/v0.4.0...v0.5.0
 [0.4]: https://github.com/madecom/photon-pump/compare/v0.3.0...v0.4.0
 [0.3]: https://github.com/madecom/photon-pump/compare/v0.2.5...v0.3

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Photon pump is available on the `cheese shop`_. ::
 
 You will need to install lib-protobuf 3.2.0 or above.
 
-Documentation is available on `Read the docs`_. ::
+Documentation is available on `Read the docs`_. 
 
 Basic Usage
 -----------
@@ -207,12 +207,12 @@ Sometimes we want to watch a stream continuously and be notified when a new even
 
 A persistent subscription stores its state on the server. When your application restarts, you can connect to the subscription again and continue where you left off. Multiple clients can connect to the same persistent subscription to support competing consumer scenarios. To support these features, persistent subscriptions have to run against the master node of an Eventstore cluster.
 
-Firstly, we need to create the subscription.
+Firstly, we need to :meth:`create the subscription <photonpump.connection.Client.create_subscription>`.
 
     >>> async def create_subscription(subscription_name, stream_name, conn):
     >>>     await conn.create_subscription(subscription_name, stream_name)
 
-Once we have a subscription, we can connect to it to begin receiving events. A persistent subscription exposes an `events` property, which acts like an asynchronous iterator.
+Once we have a subscription, we can :meth:`connect to it <photonpump.connection.Client.connect_subscription>` to begin receiving events. A persistent subscription exposes an `events` property, which acts like an asynchronous iterator.
 
     >>> async def read_events_from_subscription(subscription_name, stream_name, conn):
     >>>     subscription = await conn.connect_subscription(subscription_name, stream_name)
@@ -238,7 +238,7 @@ Volatile subsciptions do not support event acknowledgement.
 High-Availability Scenarios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Eventstore supports an HA-cluster deployment topology. In this scenario, Eventstore runs a master node and multiple slaves. Some operations, particularly subscriptions and projections, are handled only by the master node. To connect to an HA-cluster and automatically find the master node, photonpump supports cluster discovery.
+Eventstore supports an HA-cluster deployment topology. In this scenario, Eventstore runs a master node and multiple slaves. Some operations, particularly persistent subscriptions and projections, are handled only by the master node. To connect to an HA-cluster and automatically find the master node, photonpump supports cluster discovery.
 
 The cluster discovery interrogates eventstore gossip to find the active master. You can provide the IP of a maching in the cluster, or a DNS name that resolves to some members of the cluster, and photonpump will discover the others.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,3 +10,6 @@ Photonpump API Reference
 
 .. automodule:: photonpump.messages
     :members:
+
+.. automodule:: photonpump.discovery
+    :members:

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -1074,7 +1074,7 @@ def connect(
                 :class:`photonpump.disovery.DiscoveredNode` elements.
 
     """
-    discovery = get_discoverer(host, port, discovery_host, discovery_port)
+    discovery = get_discoverer(host, port, discovery_host, discovery_port, selector)
     dispatcher = MessageDispatcher(name=name, loop=loop)
     connector = Connector(discovery, dispatcher, name=name)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class PyTest(TestCommand):
 
 setup(
     name="photon-pump",
-    version="0.5.0",
+    version="0.6.0-pre-1",
     url="http://github.com/madedotcom/photon-pump/",
     license="MIT",
     author="Bob Gregory",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class PyTest(TestCommand):
 
 setup(
     name="photon-pump",
-    version="0.6.0-pre-1",
+    version="0.6.0-alpha-2",
     url="http://github.com/madedotcom/photon-pump/",
     license="MIT",
     author="Bob Gregory",


### PR DESCRIPTION
This PR adds the ability to control how we select a node from gossip.

This functionality sits alongside catch-up subscriptions to avoid overwhelming the master node. 