### PR TITLE
CreatePersistentSubscription conversations are now completed

### DIFF
--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -689,6 +689,7 @@ class CreatePersistentSubscription(Conversation):
         result.ParseFromString(message.payload)
 
         if result.result == SubscriptionResult.Success:
+            self.is_complete = True
             self.result.set_result(None)
 
         elif result.result == SubscriptionResult.AccessDenied:

--- a/test/conversations/test_create_persistent_subscription.py
+++ b/test/conversations/test_create_persistent_subscription.py
@@ -120,3 +120,13 @@ E8 07 70 0A 78 00 82 01 0A 52 6F 75 6E 64 52 6F
 
     assert actual_bytes == expected_bytes
     assert len(actual_bytes) == len(expected_bytes)
+
+
+@pytest.mark.asyncio
+async def test_persistent_subscription_success():
+
+    convo = CreatePersistentSubscription("my-other-subscription", "my-other-stream")
+
+    await complete_subscription(convo, SubscriptionResult.Success)
+
+    assert convo.is_complete


### PR DESCRIPTION
Previously, when the server sent a Success response to a CreatePersistentSubscription command, we set the Result of the conversation but did not mark the conversation complete. This meant that the dispatcher would try to resend the conversation on a re-connection and explode.