### PR TITLE
Persistent subscriptions were broken due to some confusion around

### DIFF
--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import queue
 import sys
 import time
 from asyncio import Future, Queue
@@ -604,7 +603,7 @@ class PersistentSubscription:
     async def ack(self, event):
         payload = proto.PersistentSubscriptionAckEvents()
         payload.subscription_id = self.name
-        payload.processed_event_ids.append(event.original_event_id.bytes_le)
+        payload.processed_event_ids.append(event.received_event.id.bytes_le)
         message = OutboundMessage(
             self.conversation_id,
             TcpCommand.PersistentSubscriptionAckEvents,

--- a/photonpump/messages.py
+++ b/photonpump/messages.py
@@ -301,10 +301,6 @@ class Event:
     def received_event(self) -> EventRecord:
         return self.link or self.event
 
-    @property
-    def linked_event(self) -> EventRecord:
-        return self.link
-
     def json(self):
         return json.loads(self.data.decode("UTF-8"))
 

--- a/photonpump/messages.py
+++ b/photonpump/messages.py
@@ -291,19 +291,19 @@ class Event:
         self.link = link
         self.stream = event.stream
         self.id = event.id
-        self.event_number = event.event_number
+        self.event_number = self.received_event.event_number
         self.type = event.type
         self.data = event.data
         self.metadata = event.metadata
         self.created = event.created
 
     @property
-    def original_event(self) -> EventRecord:
+    def received_event(self) -> EventRecord:
         return self.link or self.event
 
     @property
-    def original_event_id(self) -> UUID:
-        return self.original_event.id
+    def linked_event(self) -> EventRecord:
+        return self.link
 
     def json(self):
         return json.loads(self.data.decode("UTF-8"))

--- a/test/connection_test.py
+++ b/test/connection_test.py
@@ -26,7 +26,7 @@ async def test_connect_subscription(event_loop):
         await conn.publish_event(stream_name, "my-event-type", id=event_id)
 
         event = await subscription.events.anext()
-        assert event.original_event_id == event_id
+        assert event.received_event.id == event_id
 
 
 @pytest.mark.asyncio
@@ -41,4 +41,4 @@ async def test_subscribe_to(event_loop):
         subscription = await conn.subscribe_to(stream_name, start_from=0)
 
         event = await subscription.events.anext()
-        assert event.original_event_id == event_id
+        assert event.received_event.id == event_id

--- a/test/conversations/test_catchup.py
+++ b/test/conversations/test_catchup.py
@@ -120,7 +120,14 @@ class ReadStreamEventsResponseBuilder:
 
         return self
 
-    def with_event(self, event_number=10, event_id=None, type="some-event", data=None, link_event_number=None):
+    def with_event(
+        self,
+        event_number=10,
+        event_id=None,
+        type="some-event",
+        data=None,
+        link_event_number=None,
+    ):
         event = proto.ResolvedIndexedEvent()
         event.event.event_stream_id = self.stream
         event.event.event_number = event_number
@@ -136,9 +143,7 @@ class ReadStreamEventsResponseBuilder:
             event.link.event_type = "$>"
             event.link.data_content_type = msg.ContentType.Json
             event.link.metadata_content_type = msg.ContentType.Binary
-            event.link.data = f"{event_number}@{self.stream}".encode('UTF-8')
-
-
+            event.link.data = f"{event_number}@{self.stream}".encode("UTF-8")
 
         self.events.append(event)
 

--- a/test/conversations/test_persistent_subscription.py
+++ b/test/conversations/test_persistent_subscription.py
@@ -172,7 +172,11 @@ async def test_subscription_failed_midway():
 
 
 class stub_event(NamedTuple):
-    original_event_id: UUID
+    id: UUID
+
+    @property
+    def received_event(self):
+        return self
 
 
 @pytest.mark.asyncio

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -150,8 +150,8 @@ async def test_async_comprehension(event_loop):
         await given_a_stream_with_three_events(c, stream_name)
 
         jumps = (
-            e.event async
-            for e in c.iter(stream_name, batch_size=2)
+            e.event
+            async for e in c.iter(stream_name, batch_size=2)
             if e.type == "pony_jumped"
         )
         big_jumps = (embiggen(e) async for e in jumps)

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -150,8 +150,8 @@ async def test_async_comprehension(event_loop):
         await given_a_stream_with_three_events(c, stream_name)
 
         jumps = (
-            e.event
-            async for e in c.iter(stream_name, batch_size=2)
+            e.event async
+            for e in c.iter(stream_name, batch_size=2)
             if e.type == "pony_jumped"
         )
         big_jumps = (embiggen(e) async for e in jumps)


### PR DESCRIPTION
original vs received event ids. Now it works