### PR TITLE
Allow subscribing or iterating over all events

### DIFF
--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -781,7 +781,32 @@ class Client:
     ):
         correlation_id = correlation_id
         cmd = convo.IterStreamEvents(
-            stream, from_event, batch_size, resolve_links, direction=direction
+            from_event, batch_size, resolve_links,
+            direction=direction,
+            credentials=self.credential
+        )
+        result = await self.dispatcher.start_conversation(cmd)
+        iterator = await result
+        async for event in iterator:
+            yield event
+
+    async def iterAll(
+        self,
+        direction: msg.StreamDirection = msg.StreamDirection.Forward,
+        from_event: int = None,
+        batch_size: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        correlation_id: uuid.UUID = None,
+    ):
+        correlation_id = correlation_id
+        cmd = convo.IterAllEvents(
+            from_event,
+            batch_size,
+            resolve_links,
+            require_master,
+            direction=direction,
+            credentials=self.credential
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -801,7 +801,6 @@ class Client:
         resolve_links: bool = True,
         require_master: bool = False,
         correlation_id: uuid.UUID = None,
-        only_historic: bool = False,
     ):
         correlation_id = correlation_id
         cmd = convo.IterAllEvents(
@@ -811,7 +810,6 @@ class Client:
             require_master,
             direction=direction,
             credentials=self.credential,
-            only_historic=only_historic,
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -745,6 +745,30 @@ class Client:
 
         return await result
 
+    async def getAll(
+        self,
+        commit_position: int = 0,
+        direction: msg.StreamDirection = msg.StreamDirection.Forward,
+        prepare_position: int = 0,
+        max_count: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        correlation_id: uuid.UUID = None,
+    ):
+        correlation_id = correlation_id
+        cmd = convo.ReadAllEvents(
+            commit_position,
+            prepare_position,
+            max_count,
+            resolve_links,
+            require_master,
+            direction=direction,
+            credentials=self.credential
+        )
+        result = await self.dispatcher.start_conversation(cmd)
+
+        return await result
+
     async def iter(
         self,
         stream: str,

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -793,11 +793,12 @@ class Client:
     async def iterAll(
         self,
         direction: msg.StreamDirection = msg.StreamDirection.Forward,
-        from_event: int = None,
+        from_event: int = 0,
         batch_size: int = 100,
         resolve_links: bool = True,
         require_master: bool = False,
         correlation_id: uuid.UUID = None,
+        only_historic: bool = false,
     ):
         correlation_id = correlation_id
         cmd = convo.IterAllEvents(
@@ -806,7 +807,8 @@ class Client:
             resolve_links,
             require_master,
             direction=direction,
-            credentials=self.credential
+            credentials=self.credential,
+            only_historic=only_historic
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -763,7 +763,7 @@ class Client:
             resolve_links,
             require_master,
             direction=direction,
-            credentials=self.credential
+            credentials=self.credential,
         )
         result = await self.dispatcher.start_conversation(cmd)
 
@@ -781,9 +781,11 @@ class Client:
     ):
         correlation_id = correlation_id
         cmd = convo.IterStreamEvents(
-            from_event, batch_size, resolve_links,
+            from_event,
+            batch_size,
+            resolve_links,
             direction=direction,
-            credentials=self.credential
+            credentials=self.credential,
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result
@@ -808,7 +810,7 @@ class Client:
             require_master,
             direction=direction,
             credentials=self.credential,
-            only_historic=only_historic
+            only_historic=only_historic,
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -798,7 +798,7 @@ class Client:
         resolve_links: bool = True,
         require_master: bool = False,
         correlation_id: uuid.UUID = None,
-        only_historic: bool = false,
+        only_historic: bool = False,
     ):
         correlation_id = correlation_id
         cmd = convo.IterAllEvents(

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -781,11 +781,7 @@ class Client:
     ):
         correlation_id = correlation_id
         cmd = convo.IterStreamEvents(
-            from_event,
-            batch_size,
-            resolve_links,
-            direction=direction,
-            credentials=self.credential,
+            stream, from_event, batch_size, resolve_links, direction=direction, credentials=self.credential
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -781,7 +781,12 @@ class Client:
     ):
         correlation_id = correlation_id
         cmd = convo.IterStreamEvents(
-            stream, from_event, batch_size, resolve_links, direction=direction, credentials=self.credential
+            stream,
+            from_event,
+            batch_size,
+            resolve_links,
+            direction=direction,
+            credentials=self.credential,
         )
         result = await self.dispatcher.start_conversation(cmd)
         iterator = await result

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -662,6 +662,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         )
         self.batch_size = batch_size
         self.commit_position = from_event
+        self.only_historic = only_historic
         self.has_first_page = False
         self.resolve_link_tos = resolve_links
         self.require_master = require_master

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -680,7 +680,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         await output.put(self._fetch_page_message(self.from_event))
 
     async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
-        no_new_events = only_historic and result.commit_position == result.next_commit_position
+        no_new_events = self.only_historic and result.commit_position == result.next_commit_position
         if no_new_events:
             self.is_complete = True
             await self.iterator.asend(StopAsyncIteration())

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -647,12 +647,13 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
     def __init__(
         self,
         from_event: int = 0,
-        batch_size: int = 100,
+        batch_size: int = 500,
         resolve_links: bool = True,
         require_master: bool = False,
         direction: StreamDirection = StreamDirection.Forward,
         credentials=None,
         conversation_id: UUID = None,
+        only_historic: bool = false
     ):
 
         Conversation.__init__(self, conversation_id, credentials)
@@ -679,6 +680,10 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         await output.put(self._fetch_page_message(self.from_event))
 
     async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
+        no_new_events = only_historic and result.commit_position == result.next_commit_position
+        if no_new_events:
+            self.is_complete = True
+            await self.iterator.asend(StopAsyncIteration())
 
         if result.error == '':
             await output.put(self._fetch_page_message(result.next_commit_position))

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -653,7 +653,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         direction: StreamDirection = StreamDirection.Forward,
         credentials=None,
         conversation_id: UUID = None,
-        only_historic: bool = false
+        only_historic: bool = False
     ):
 
         Conversation.__init__(self, conversation_id, credentials)

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -316,7 +316,7 @@ class ReadAllEventsBehaviour:
             await self.success(result, output)
         elif result.result == self.result_type.Error:
             await self.error(
-                exceptions.ReadError(self.conversation_id, self.stream, result.error)
+                exceptions.ReadError(self.conversation_id, "$all", result.error)
             )
         elif result.result == self.result_type.AccessDenied:
             await self.error(
@@ -330,7 +330,7 @@ class ReadAllEventsBehaviour:
         ):
             await self.error(
                 exceptions.EventNotFound(
-                    self.conversation_id, self.stream, self.event_number
+                    self.conversation_id, "$all", self.event_number
                 )
             )
 
@@ -696,10 +696,6 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         if not self.has_first_page:
             self.result.set_result(self.iterator)
             self.has_first_page = True
-
-        if not result.error == "":
-            self.is_complete = True
-            await self.iterator.asend(StopAsyncIteration())
 
     async def error(self, exn: Exception) -> None:
         self.is_complete = True

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -321,9 +321,7 @@ class ReadAllEventsBehaviour:
         elif result.result == self.result_type.AccessDenied:
             await self.error(
                 exceptions.AccessDenied(
-                    self.conversation_id,
-                    type(self).__name__,
-                    result.error
+                    self.conversation_id, type(self).__name__, result.error
                 )
             )
         elif (
@@ -335,6 +333,7 @@ class ReadAllEventsBehaviour:
                     self.conversation_id, self.stream, self.event_number
                 )
             )
+
 
 class ReadStreamEventsBehaviour:
     def __init__(self, result_type, response_cls):
@@ -435,6 +434,7 @@ class ReadEvent(ReadStreamEventsBehaviour, Conversation):
         self.is_complete = True
         self.result.set_result(_make_event(response.event))
 
+
 class PageAllEventsBehaviour(Conversation):
     def _fetch_page_message(self, commit_position):
         if self.direction == StreamDirection.Forward:
@@ -478,6 +478,7 @@ class PageStreamEventsBehaviour(Conversation):
     async def start(self, output):
         await output.put(self._fetch_page_message(self.from_event))
 
+
 class ReadAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
     """Command class for reading all events from a stream.
 
@@ -491,6 +492,7 @@ class ReadAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         correlation_id (optional): A unique identifer for this
             command.
     """
+
     def __init__(
         self,
         commit_position: int = 0,
@@ -531,9 +533,7 @@ class ReadAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
 
     def _fetch_page_message(self, from_event):
         self._logger.debug(
-            "Requesting page of %d events from number %d",
-            self.max_count,
-            from_event,
+            "Requesting page of %d events from number %d", self.max_count, from_event
         )
 
         if self.direction == StreamDirection.Forward:
@@ -630,7 +630,6 @@ class ReadStreamEvents(ReadStreamEventsBehaviour, PageStreamEventsBehaviour):
         return OutboundMessage(self.conversation_id, command, data, self.credential)
 
 
-
 class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
     """Command class for iterating events from all events.
 
@@ -653,7 +652,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         direction: StreamDirection = StreamDirection.Forward,
         credentials=None,
         conversation_id: UUID = None,
-        only_historic: bool = False
+        only_historic: bool = False,
     ):
 
         Conversation.__init__(self, conversation_id, credentials)
@@ -681,12 +680,14 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         await output.put(self._fetch_page_message(self.from_event))
 
     async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
-        no_new_events = self.only_historic and result.commit_position == result.next_commit_position
+        no_new_events = (
+            self.only_historic and result.commit_position == result.next_commit_position
+        )
         if no_new_events:
             self.is_complete = True
             await self.iterator.asend(StopAsyncIteration())
 
-        if result.error == '':
+        if result.error == "":
             await output.put(self._fetch_page_message(result.next_commit_position))
 
         events = [_make_event(x) for x in result.events]
@@ -696,7 +697,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
             self.result.set_result(self.iterator)
             self.has_first_page = True
 
-        if not result.error == '':
+        if not result.error == "":
             self.is_complete = True
             await self.iterator.asend(StopAsyncIteration())
 

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -652,7 +652,6 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         direction: StreamDirection = StreamDirection.Forward,
         credentials=None,
         conversation_id: UUID = None,
-        only_historic: bool = False,
     ):
 
         Conversation.__init__(self, conversation_id, credentials)
@@ -661,7 +660,6 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         )
         self.batch_size = batch_size
         self.commit_position = from_event
-        self.only_historic = only_historic
         self.has_first_page = False
         self.resolve_link_tos = resolve_links
         self.require_master = require_master
@@ -680,9 +678,7 @@ class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
         await output.put(self._fetch_page_message(self.from_event))
 
     async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
-        no_new_events = (
-            self.only_historic and result.commit_position == result.next_commit_position
-        )
+        no_new_events = result.commit_position == result.next_commit_position
         if no_new_events:
             self.is_complete = True
             await self.iterator.asend(StopAsyncIteration())

--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -20,8 +20,10 @@ from photonpump.messages import (
     OutboundMessage,
     ReadEventResult,
     ReadStreamResult,
+    ReadAllResult,
     StreamDirection,
     StreamSlice,
+    AllStreamSlice,
     SubscriptionResult,
     TcpCommand,
     _make_event,
@@ -298,6 +300,42 @@ class WriteEvents(Conversation):
         self.result.set_result(result)
 
 
+class ReadAllEventsBehaviour:
+    def __init__(self, result_type, response_cls):
+        self.result_type = result_type
+        self.response_cls = response_cls
+
+    def success(self, result, output: Queue):
+        pass
+
+    async def reply(self, message: InboundMessage, output: Queue):
+        result = self.response_cls()
+        result.ParseFromString(message.payload)
+
+        if result.result == self.result_type.Success:
+            await self.success(result, output)
+        elif result.result == self.result_type.Error:
+            await self.error(
+                exceptions.ReadError(self.conversation_id, self.stream, result.error)
+            )
+        elif result.result == self.result_type.AccessDenied:
+            await self.error(
+                exceptions.AccessDenied(
+                    self.conversation_id,
+                    type(self).__name__,
+                    result.error
+                )
+            )
+        elif (
+            self.result_type == ReadEventResult
+            and result.result == self.result_type.NotFound
+        ):
+            await self.error(
+                exceptions.EventNotFound(
+                    self.conversation_id, self.stream, self.event_number
+                )
+            )
+
 class ReadStreamEventsBehaviour:
     def __init__(self, result_type, response_cls):
         self.result_type = result_type
@@ -397,6 +435,27 @@ class ReadEvent(ReadStreamEventsBehaviour, Conversation):
         self.is_complete = True
         self.result.set_result(_make_event(response.event))
 
+class PageAllEventsBehaviour(Conversation):
+    def _fetch_page_message(self, commit_position):
+        if self.direction == StreamDirection.Forward:
+            command = TcpCommand.ReadAllEventsForward
+        else:
+            command = TcpCommand.ReadAllEventsBackward
+
+        msg = proto.ReadAllEvents()
+        msg.commit_position = commit_position
+        msg.prepare_position = commit_position
+        msg.max_count = self.batch_size
+        msg.resolve_link_tos = self.resolve_link_tos
+        msg.require_master = self.require_master
+
+        data = msg.SerializeToString()
+
+        return OutboundMessage(self.conversation_id, command, data, self.credential)
+
+    async def start(self, output):
+        await output.put(self._fetch_page_message(self.commit_position))
+
 
 class PageStreamEventsBehaviour(Conversation):
     def _fetch_page_message(self, from_event):
@@ -418,6 +477,80 @@ class PageStreamEventsBehaviour(Conversation):
 
     async def start(self, output):
         await output.put(self._fetch_page_message(self.from_event))
+
+class ReadAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
+    """Command class for reading all events from a stream.
+
+    Args:
+        commit_position: The commit_position.
+        event_number: The sequence number of the event to read.
+        resolve_links (optional): True if eventstore should
+            automatically resolve Link Events, otherwise False.
+        required_master (optional): True if this command must be
+            sent direct to the master node, otherwise False.
+        correlation_id (optional): A unique identifer for this
+            command.
+    """
+    def __init__(
+        self,
+        commit_position: int = 0,
+        prepare_position: int = 0,
+        max_count: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        direction: StreamDirection = StreamDirection.Forward,
+        credentials=None,
+        conversation_id: UUID = None,
+    ) -> None:
+
+        Conversation.__init__(self, conversation_id, credential=credentials)
+        ReadStreamEventsBehaviour.__init__(
+            self, ReadAllResult, proto.ReadAllEventsCompleted
+        )
+        self.has_first_page = False
+        self.direction = direction
+        self.commit_position = commit_position
+        self.prepare_position = prepare_position
+        self.max_count = max_count
+        self.require_master = require_master
+        self.resolve_link_tos = resolve_links
+
+    async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
+        events = [_make_event(x) for x in result.events]
+
+        self.is_complete = True
+        self.result.set_result(
+            AllStreamSlice(
+                events,
+                result.next_commit_position,
+                result.next_prepare_position,
+                result.commit_position,
+                result.prepare_position,
+            )
+        )
+
+    def _fetch_page_message(self, from_event):
+        self._logger.debug(
+            "Requesting page of %d events from number %d",
+            self.max_count,
+            from_event,
+        )
+
+        if self.direction == StreamDirection.Forward:
+            command = TcpCommand.ReadAllEventsForward
+        else:
+            command = TcpCommand.ReadAllEventsBackward
+
+        msg = proto.ReadAllEvents()
+        msg.commit_position = from_event
+        msg.prepare_position = self.prepare_position
+        msg.max_count = self.max_count
+        msg.require_master = self.require_master
+        msg.resolve_link_tos = self.resolve_link_tos
+
+        data = msg.SerializeToString()
+
+        return OutboundMessage(self.conversation_id, command, data, self.credential)
 
 
 class ReadStreamEvents(ReadStreamEventsBehaviour, PageStreamEventsBehaviour):
@@ -495,6 +628,79 @@ class ReadStreamEvents(ReadStreamEventsBehaviour, PageStreamEventsBehaviour):
         data = msg.SerializeToString()
 
         return OutboundMessage(self.conversation_id, command, data, self.credential)
+
+
+
+class IterAllEvents(ReadAllEventsBehaviour, PageAllEventsBehaviour):
+    """Command class for iterating events from all events.
+
+    Args:
+        resolve_links (optional): True if eventstore should
+            automatically resolve Link Events, otherwise False.
+        required_master (optional): True if this command must be
+            sent direct to the master node, otherwise False.
+        correlation_id (optional): A unique identifer for this
+            command.
+
+    """
+
+    def __init__(
+        self,
+        from_event: int = 0,
+        batch_size: int = 100,
+        resolve_links: bool = True,
+        require_master: bool = False,
+        direction: StreamDirection = StreamDirection.Forward,
+        credentials=None,
+        conversation_id: UUID = None,
+    ):
+
+        Conversation.__init__(self, conversation_id, credentials)
+        ReadAllEventsBehaviour.__init__(
+            self, ReadAllResult, proto.ReadAllEventsCompleted
+        )
+        self.batch_size = batch_size
+        self.commit_position = from_event
+        self.has_first_page = False
+        self.resolve_link_tos = resolve_links
+        self.require_master = require_master
+        self.direction = direction
+        self._logger = logging.get_named_logger(IterAllEvents)
+        self.iterator = StreamingIterator(self.batch_size)
+
+        if direction == StreamDirection.Forward:
+            self.command = TcpCommand.ReadAllEventsForward
+            self.from_event = from_event or 0
+        else:
+            self.command = TcpCommand.ReadAllEventsBackward
+            self.from_event = from_event or -1
+
+    async def start(self, output: Queue):
+        await output.put(self._fetch_page_message(self.from_event))
+
+    async def success(self, result: proto.ReadAllEventsCompleted, output: Queue):
+
+        if result.error == '':
+            await output.put(self._fetch_page_message(result.next_commit_position))
+
+        events = [_make_event(x) for x in result.events]
+        await self.iterator.enqueue_items(events)
+
+        if not self.has_first_page:
+            self.result.set_result(self.iterator)
+            self.has_first_page = True
+
+        if not result.error == '':
+            self.is_complete = True
+            await self.iterator.asend(StopAsyncIteration())
+
+    async def error(self, exn: Exception) -> None:
+        self.is_complete = True
+
+        if self.has_first_page:
+            await self.iterator.asend(exn)
+        else:
+            self.result.set_exception(exn)
 
 
 class IterStreamEvents(ReadStreamEventsBehaviour, PageStreamEventsBehaviour):

--- a/photonpump/messages.py
+++ b/photonpump/messages.py
@@ -305,7 +305,7 @@ class Event:
         return json.loads(self.data.decode("UTF-8"))
 
     def __repr__(self):
-        return f"<Event: {self.event_number}@{self.stream}:{self.type}>"
+        return f"<Event {self.created}: {self.event_number}@{self.stream}:{self.type}>"
 
 
 class StreamSlice(list):
@@ -326,6 +326,22 @@ class StreamSlice(list):
         self.is_end_of_stream = is_end_of_stream
         self.events = events
 
+
+class AllStreamSlice(list):
+    def __init__(
+        self,
+        events: Sequence[Event],
+        next_commit_position: int,
+        next_prepare_position: int,
+        prepare_position: int = None,
+        commit_position: int = None,
+    ) -> None:
+        super().__init__(events)
+        self.next_commit_position = next_commit_position
+        self.next_prepare_position = next_prepare_position
+        self.prepare_position = prepare_position
+        self.commit_position = commit_position
+        self.events = events
 
 def dump(*chunks: bytearray):
     data = bytearray()
@@ -397,7 +413,9 @@ def NewEvent(
 
 ReadEventResult = make_enum(messages_pb2._READEVENTCOMPLETED_READEVENTRESULT)
 
-ReadStreamResult = make_enum(messages_pb2._READSTREAMEVENTSCOMPLETED_READSTREAMRESULT)
+ReadStreamResult =  make_enum(messages_pb2._READSTREAMEVENTSCOMPLETED_READSTREAMRESULT)
+
+ReadAllResult =     make_enum(messages_pb2._READALLEVENTSCOMPLETED_READALLRESULT)
 
 SubscriptionResult = make_enum(
     messages_pb2._CREATEPERSISTENTSUBSCRIPTIONCOMPLETED_CREATEPERSISTENTSUBSCRIPTIONRESULT

--- a/photonpump/messages.py
+++ b/photonpump/messages.py
@@ -343,6 +343,7 @@ class AllStreamSlice(list):
         self.commit_position = commit_position
         self.events = events
 
+
 def dump(*chunks: bytearray):
     data = bytearray()
 
@@ -413,9 +414,9 @@ def NewEvent(
 
 ReadEventResult = make_enum(messages_pb2._READEVENTCOMPLETED_READEVENTRESULT)
 
-ReadStreamResult =  make_enum(messages_pb2._READSTREAMEVENTSCOMPLETED_READSTREAMRESULT)
+ReadStreamResult = make_enum(messages_pb2._READSTREAMEVENTSCOMPLETED_READSTREAMRESULT)
 
-ReadAllResult =     make_enum(messages_pb2._READALLEVENTSCOMPLETED_READALLRESULT)
+ReadAllResult = make_enum(messages_pb2._READALLEVENTSCOMPLETED_READALLRESULT)
 
 SubscriptionResult = make_enum(
     messages_pb2._CREATEPERSISTENTSUBSCRIPTIONCOMPLETED_CREATEPERSISTENTSUBSCRIPTIONRESULT

--- a/test/conversations/test_read_all_events_stream_conversation.py
+++ b/test/conversations/test_read_all_events_stream_conversation.py
@@ -1,0 +1,170 @@
+from asyncio import Queue
+from uuid import uuid4
+
+import pytest
+
+from photonpump import messages as msg, exceptions
+from photonpump import messages_pb2 as proto
+from photonpump.conversations import ReadAllEvents
+
+
+@pytest.mark.asyncio
+async def test_read_all_request():
+
+    output = Queue()
+
+    convo = ReadAllEvents(commit_position=10, prepare_position=11)
+    await convo.start(output)
+    request = await output.get()
+
+    body = proto.ReadAllEvents()
+    body.ParseFromString(request.payload)
+
+    assert request.command is msg.TcpCommand.ReadAllEventsForward
+    assert body.commit_position == 10
+    assert body.prepare_position == 11
+    assert body.resolve_link_tos is True
+    assert body.require_master is False
+    assert body.max_count == 100
+
+
+@pytest.mark.asyncio
+async def test_read_stream_backward():
+
+    output = Queue()
+    convo = ReadAllEvents(
+        commit_position=10,
+        prepare_position=11,
+        direction=msg.StreamDirection.Backward,
+        max_count=20,
+    )
+    await convo.start(output)
+    request = await output.get()
+
+    body = proto.ReadAllEvents()
+    body.ParseFromString(request.payload)
+
+    assert request.command is msg.TcpCommand.ReadAllEventsBackward
+    assert body.commit_position == 10
+    assert body.prepare_position == 11
+    assert body.resolve_link_tos is True
+    assert body.require_master is False
+    assert body.max_count == 20
+
+
+@pytest.mark.asyncio
+async def test_read_all_success():
+
+    event_1_id = uuid4()
+    event_2_id = uuid4()
+
+    convo = ReadAllEvents()
+    response = proto.ReadAllEventsCompleted()
+    response.result = msg.ReadEventResult.Success
+    response.next_commit_position = 10
+    response.next_prepare_position = 10
+    response.commit_position = 9
+    response.prepare_position = 9
+
+    event_1 = proto.ResolvedEvent()
+    event_1.commit_position = 8
+    event_1.prepare_position = 8
+    event_1.event.event_stream_id = "stream-123"
+    event_1.event.event_number = 32
+    event_1.event.event_id = event_1_id.bytes_le
+    event_1.event.event_type = "event-type"
+    event_1.event.data_content_type = msg.ContentType.Json
+    event_1.event.metadata_content_type = msg.ContentType.Binary
+    event_1.event.data = """
+    {
+        'color': 'red',
+        'winner': true
+    }
+    """.encode(
+        "UTF-8"
+    )
+
+    event_2 = proto.ResolvedEvent()
+    event_2.CopyFrom(event_1)
+    event_2.event.event_stream_id = "stream-456"
+    event_2.event.event_type = "event-2-type"
+    event_2.event.event_id = event_2_id.bytes_le
+    event_2.event.event_number = 32
+
+    response.events.extend([event_1, event_2])
+
+    await convo.respond_to(
+        msg.InboundMessage(
+            uuid4(),
+            msg.TcpCommand.ReadAllEventsForwardCompleted,
+            response.SerializeToString(),
+        ),
+        None,
+    )
+
+    result = await convo.result
+
+    assert isinstance(result, msg.AllStreamSlice)
+
+    [event_1, event_2] = result.events
+    assert event_1.stream == "stream-123"
+    assert event_1.id == event_1_id
+    assert event_1.type == "event-type"
+    assert event_1.event_number == 32
+
+    assert event_2.stream == "stream-456"
+    assert event_2.id == event_2_id
+    assert event_2.type == "event-2-type"
+    assert event_2.event_number == 32
+
+
+@pytest.mark.asyncio
+async def test_all_events_error():
+
+    convo = ReadAllEvents()
+    response = proto.ReadAllEventsCompleted()
+    response.result = msg.ReadAllResult.Error
+    response.next_commit_position = 10
+    response.next_prepare_position = 10
+    response.commit_position = 9
+    response.prepare_position = 9
+    response.error = "Something really weird just happened"
+
+    await convo.respond_to(
+        msg.InboundMessage(
+            uuid4(),
+            msg.TcpCommand.ReadAllEventsForwardCompleted,
+            response.SerializeToString(),
+        ),
+        None,
+    )
+
+    with pytest.raises(exceptions.ReadError) as exn:
+        await convo.result
+        assert exn.stream == "$all"
+        assert exn.conversation_id == convo.conversation_id
+
+
+@pytest.mark.asyncio
+async def test_all_events_access_denied():
+
+    convo = ReadAllEvents()
+    response = proto.ReadAllEventsCompleted()
+    response.result = msg.ReadAllResult.AccessDenied
+    response.next_commit_position = 10
+    response.next_prepare_position = 10
+    response.commit_position = 9
+    response.prepare_position = 9
+
+    await convo.respond_to(
+        msg.InboundMessage(
+            uuid4(), msg.TcpCommand.ReadAllEventsForward, response.SerializeToString()
+        ),
+        None,
+    )
+
+    with pytest.raises(exceptions.AccessDenied) as exn:
+        await convo.result
+
+        assert exn.conversation_id == convo.conversation_id
+        assert exn.conversation_type == "ReadAllEvents"

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -20,32 +20,31 @@ async def given_a_stream_with_three_events(c, stream_name):
         ],
     )
 
+
 async def given_two_streams_with_two_events(c):
     await c.publish(
         "stream_one",
         [
             messages.NewEvent(
-                "pony_jumped",
+                "pony_splits",
                 data={"Pony": "Derpy Hooves", "Height": 10, "Distance": 13},
             ),
             messages.NewEvent(
-                "pony_jumped",
+                "pony_splits",
                 data={"Pony": "Sparkly Hooves", "Height": 4, "Distance": 9},
             ),
-            
         ],
     )
     await c.publish(
         "stream_two",
         [
             messages.NewEvent(
-                "pony_jumped",
+                "pony_splits",
                 data={"Pony": "Unlikely Hooves", "Height": 63, "Distance": 23},
             ),
             messages.NewEvent(
-                "pony_jumped",
+                "pony_splits",
                 data={"Pony": "Glitter Hooves", "Height": 11, "Distance": 94},
             ),
-            
         ],
     )

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -19,3 +19,33 @@ async def given_a_stream_with_three_events(c, stream_name):
             ),
         ],
     )
+
+async def given_two_streams_with_two_events(c):
+    await c.publish(
+        "stream_one",
+        [
+            messages.NewEvent(
+                "pony_jumped",
+                data={"Pony": "Derpy Hooves", "Height": 10, "Distance": 13},
+            ),
+            messages.NewEvent(
+                "pony_jumped",
+                data={"Pony": "Sparkly Hooves", "Height": 4, "Distance": 9},
+            ),
+            
+        ],
+    )
+    await c.publish(
+        "stream_two",
+        [
+            messages.NewEvent(
+                "pony_jumped",
+                data={"Pony": "Unlikely Hooves", "Height": 63, "Distance": 23},
+            ),
+            messages.NewEvent(
+                "pony_jumped",
+                data={"Pony": "Glitter Hooves", "Height": 11, "Distance": 94},
+            ),
+            
+        ],
+    )

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -21,9 +21,9 @@ async def given_a_stream_with_three_events(c, stream_name):
     )
 
 
-async def given_two_streams_with_two_events(c):
+async def given_two_streams_with_two_events(c, id):
     await c.publish(
-        "stream_one",
+        "stream_one_{}".format(id),
         [
             messages.NewEvent(
                 "pony_splits",
@@ -36,7 +36,7 @@ async def given_two_streams_with_two_events(c):
         ],
     )
     await c.publish(
-        "stream_two",
+        "stream_two_{}".format(id),
         [
             messages.NewEvent(
                 "pony_splits",

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -5,7 +5,10 @@ import pytest
 
 from photonpump import connect, exceptions, messages
 
-from .fixtures import given_a_stream_with_three_events
+from .fixtures import (
+    given_a_stream_with_three_events,
+    given_two_streams_with_two_events,
+)
 
 
 @pytest.mark.asyncio
@@ -174,3 +177,37 @@ async def test_iter_from_missing_stream(event_loop):
             assert False
         except Exception as e:
             assert isinstance(e, exceptions.StreamNotFound)
+
+
+@pytest.mark.asyncio
+async def test_iter_all(event_loop):
+
+    async with connect(
+        loop=event_loop, name="iter-all", username="admin", password="changeit"
+    ) as c:
+        await given_two_streams_with_two_events(c)
+
+        result = await c.getAll(max_count=4096)
+
+        assert isinstance(result, list)
+        assert len(result) > 4
+
+        stream_one_events = []
+        stream_two_events = []
+
+        for event in result:
+            if event.stream == "stream_one":
+                stream_one_events.append(event)
+            if event.stream == "stream_two":
+                stream_two_events.append(event)
+
+        assert len(stream_one_events) >= 2
+        assert len(stream_two_events) >= 2
+        event_data = stream_one_events[0].json()
+        assert event_data["Pony"] == "Derpy Hooves"
+        event_data = stream_one_events[1].json()
+        assert event_data["Pony"] == "Sparkly Hooves"
+        event_data = stream_two_events[0].json()
+        assert event_data["Pony"] == "Unlikely Hooves"
+        event_data = stream_two_events[1].json()
+        assert event_data["Pony"] == "Glitter Hooves"

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -180,7 +180,7 @@ async def test_iter_from_missing_stream(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_iter_all(event_loop):
+async def test_get_all(event_loop):
 
     async with connect(
         loop=event_loop, name="iter-all", username="admin", password="changeit"
@@ -211,3 +211,20 @@ async def test_iter_all(event_loop):
         assert event_data["Pony"] == "Unlikely Hooves"
         event_data = stream_two_events[1].json()
         assert event_data["Pony"] == "Glitter Hooves"
+
+
+@pytest.mark.asyncio
+async def test_iter_all(event_loop):
+
+    async with connect(
+        loop=event_loop, name="iter-all", username="admin", password="changeit"
+    ) as c:
+        await given_two_streams_with_two_events(c)
+
+        events_read = 0
+
+        async for event in c.iterAll(batch_size=1):
+            if event.stream == "stream_one" or event.stream == "stream_two":
+                events_read += 1
+
+        assert events_read == 4

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -185,7 +185,7 @@ async def test_get_all(event_loop):
     async with connect(
         loop=event_loop, name="iter-all", username="admin", password="changeit"
     ) as c:
-        await given_two_streams_with_two_events(c)
+        await given_two_streams_with_two_events(c, "get_all")
 
         result = await c.getAll(max_count=4096)
 
@@ -196,13 +196,13 @@ async def test_get_all(event_loop):
         stream_two_events = []
 
         for event in result:
-            if event.stream == "stream_one":
+            if event.stream == "stream_one_get_all":
                 stream_one_events.append(event)
-            if event.stream == "stream_two":
+            if event.stream == "stream_two_get_all":
                 stream_two_events.append(event)
 
-        assert len(stream_one_events) >= 2
-        assert len(stream_two_events) >= 2
+        assert len(stream_one_events) == 2
+        assert len(stream_two_events) == 2
         event_data = stream_one_events[0].json()
         assert event_data["Pony"] == "Derpy Hooves"
         event_data = stream_one_events[1].json()
@@ -219,12 +219,12 @@ async def test_iter_all(event_loop):
     async with connect(
         loop=event_loop, name="iter-all", username="admin", password="changeit"
     ) as c:
-        await given_two_streams_with_two_events(c)
+        await given_two_streams_with_two_events(c, "iter_all")
 
         events_read = 0
 
         async for event in c.iterAll(batch_size=1):
-            if event.stream == "stream_one" or event.stream == "stream_two":
+            if event.stream == "stream_one_iter_all" or event.stream == "stream_two_iter_all":
                 events_read += 1
 
         assert events_read == 4

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -224,7 +224,10 @@ async def test_iter_all(event_loop):
         events_read = 0
 
         async for event in c.iterAll(batch_size=1):
-            if event.stream == "stream_one_iter_all" or event.stream == "stream_two_iter_all":
+            if (
+                event.stream == "stream_one_iter_all"
+                or event.stream == "stream_two_iter_all"
+            ):
                 events_read += 1
 
         assert events_read == 4


### PR DESCRIPTION
This is a working implementation of streaming all events in the EventStore for issue #78 

At the moment it has no unit tests and probably does not follow the correct code standard

It also passes the credentials into the iterator for streams