### PR TITLE
Support binary event data

### DIFF
--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -278,6 +278,9 @@ class WriteEvents(Conversation):
             if isinstance(event.data, str):
                 e.data_content_type = ContentType.Json
                 e.data = event.data.encode("UTF-8")
+            elif isinstance(event.data, bytes):
+                e.data_content_type = ContentType.Binary
+                e.data = event.data
             elif event.data:
                 e.data_content_type = ContentType.Json
                 e.data = json.dumps(event.data).encode("UTF-8")


### PR DESCRIPTION
- Allow for raw bytes instances to be used (as already supported by underlying protocol)