### PR TITLE
Add exception to expose existing (persistent) subscription response

### DIFF
--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -912,6 +912,14 @@ class CreatePersistentSubscription(Conversation):
                     self.conversation_id, type(self).__name__, result.reason
                 )
             )
+
+        elif result.result == SubscriptionResult.AlreadyExists:
+            await self.error(
+                exceptions.SubscriptionGroupAlreadyExists(
+                    self.conversation_id, type(self).__name__, result.reason
+                )
+            )
+
         else:
             await self.error(
                 exceptions.SubscriptionCreationFailed(

--- a/photonpump/exceptions.py
+++ b/photonpump/exceptions.py
@@ -108,6 +108,10 @@ class SubscriptionCreationFailed(ConversationException):
     pass
 
 
+class SubscriptionGroupAlreadyExists(ConversationException):
+    pass
+
+
 class SubscriptionFailed(ConversationException):
     pass
 

--- a/test/conversations/test_create_persistent_subscription.py
+++ b/test/conversations/test_create_persistent_subscription.py
@@ -65,7 +65,7 @@ async def test_persistent_subscription_already_exists():
         output,
     )
 
-    with pytest.raises(exceptions.SubscriptionCreationFailed):
+    with pytest.raises(exceptions.SubscriptionGroupAlreadyExists):
         await convo.result
 
 


### PR DESCRIPTION
- Distinguish creation failure from already-existing state