### PR TITLE
Strip out a bunch of calls to the root logger

### DIFF
--- a/photonpump/conversations.py
+++ b/photonpump/conversations.py
@@ -432,7 +432,9 @@ class ReadEvent(ReadStreamEventsBehaviour, Conversation):
                 self.conversation_id, TcpCommand.Read, data, self.credential
             )
         )
-        self._logger.debug("ReadEvent started on %s (%s)", self.stream, self.conversation_id)
+        self._logger.debug(
+            "ReadEvent started on %s (%s)", self.stream, self.conversation_id
+        )
 
     async def success(self, response, output: Queue):
         self.is_complete = True
@@ -460,7 +462,9 @@ class PageStreamEventsBehaviour(Conversation):
 
     async def start(self, output):
         await output.put(self._fetch_page_message(self.from_event))
-        self._logger.debug("PageStreamEventsBehaviour started (%s)", self.conversation_id)
+        self._logger.debug(
+            "PageStreamEventsBehaviour started (%s)", self.conversation_id
+        )
 
 
 class ReadAllEvents(ReadAllEventsBehaviour, Conversation):


### PR DESCRIPTION
switched on DEBUG level logging on the root logger for a project and was overwhelmed with spam from a few photonpump classes, and unable to disable them by using the normal namespaces bc they're using the root logger.

hacky first cut fix, no tests run.