### PR TITLE
Recover from connection failures

### DIFF
--- a/photonpump/connection.py
+++ b/photonpump/connection.py
@@ -1,4 +1,5 @@
 import array
+import concurrent.futures
 import asyncio
 import enum
 import logging
@@ -364,8 +365,10 @@ class MessageWriter:
             try:
                 await self.writer.drain()
                 self._logger.debug("Finished drain for %s", msg)
+            except concurrent.futures.CancelledError as e:
+                return
             except Exception as e:
-                self._logger.error(e)
+                self._logger.exception(e)
 
 
 class MessageReader:

--- a/photonpump/discovery.py
+++ b/photonpump/discovery.py
@@ -355,8 +355,10 @@ class DiscoveryRetryPolicy:
 
     def should_retry(self, node):
         stats = self.stats[node]
-
-        return stats.consecutive_failures < self.retries_per_node
+        return (
+            self.retries_per_node == 0
+            or stats.consecutive_failures < self.retries_per_node
+        )
 
     async def wait(self, seed):
         stats = self.stats[seed]


### PR DESCRIPTION
currently the messagewriter is swallowing asyncio  coroutine-cancellation errors and staying stuck in its while True loop, meaning we can never reconnect/recover from connection failures.

also the default was "never retry" which was probably bad.